### PR TITLE
[PR1] DEV-56 Added TabLayout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "axios": "^1.1.3",
         "dotenv": "^16.0.3",
         "events": "^3.3.0",
+        "nanoid": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.6.0",
         "react-redux": "^8.0.5"
       },
       "devDependencies": {
@@ -3261,15 +3263,14 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
+      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/nock": {
@@ -3446,6 +3447,18 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -3543,6 +3556,14 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.6.0.tgz",
+      "integrity": "sha512-rR/L9m9340yO8yv1QT1QurxWQvWpbNHqVX0fzMln2HEb9TEIrQRGsqiNFQfiv9/JEUbyHmHPlNTB2LWm2Ttz0g==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {
@@ -6578,10 +6599,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
+      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
     },
     "nock": {
       "version": "13.2.9",
@@ -6703,6 +6723,14 @@
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+          "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+          "dev": true
+        }
       }
     },
     "prelude-ls": {
@@ -6781,6 +6809,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-icons": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.6.0.tgz",
+      "integrity": "sha512-rR/L9m9340yO8yv1QT1QurxWQvWpbNHqVX0fzMln2HEb9TEIrQRGsqiNFQfiv9/JEUbyHmHPlNTB2LWm2Ttz0g==",
+      "requires": {}
     },
     "react-is": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "axios": "^1.1.3",
     "dotenv": "^16.0.3",
     "events": "^3.3.0",
+    "nanoid": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.6.0",
     "react-redux": "^8.0.5"
   },
   "devDependencies": {

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,6 @@
-body {
-  margin: 0;
+.App {
+  width: 100%;
+  height: 100%;
+  background-color: #496c8c;
+  padding: 2rem;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,42 @@
 import "./App.css";
-import * as dotenv from "dotenv";
 import { DataService } from "@services/DataService";
 import { OrderService } from "@services/OrderService";
-import { ReceiveTable } from "@components/PacketTable/ReceiveTable/ReceiveTable";
+import { HomePage } from "@pages/HomePage/HomePage";
+import { Chart } from "@components/Chart/Chart";
+import { Axis } from "@components/Chart/Axis";
+import { useState, useEffect } from "react";
 
+type Point = [number, number];
+let index = 0;
 function App() {
+  // let [points, setPoints] = useState([] as Point[]);
+  // useEffect(() => {
+  //   let intervalId = setInterval(() => {
+  //     setPoints((prevPoints) => {
+  //       let newPoints = [
+  //         ...prevPoints,
+  //         [index, Math.floor(Math.random() * 100)],
+  //       ] as Point[];
+
+  //       if (newPoints.length > 100) {
+  //         newPoints.shift();
+  //       }
+
+  //       return newPoints;
+  //     });
+  //     index++;
+  //   }, 1000 / 60);
+  //   return () => {
+  //     clearInterval(intervalId);
+  //   };
+  // }, []);
   return (
     <div className="App">
+      {/* <Axis maxY={10 / 10} minY={-5 / 10} /> */}
+      {/* <Chart points={points} /> */}
       <DataService>
         <OrderService>
-          <ReceiveTable></ReceiveTable>
+          <HomePage />
         </OrderService>
       </DataService>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,17 @@
+body {
+  margin: 0;
+  padding: 0;
+  /*TODO: cambiar width y height para que si haces la ventana mas pequeña, los componentes se hacen */
+  width: 100vw;
+  height: 100vh;
+}
+* {
+  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+}
+
+#root {
+  width: 100%;
+  height: 100%;
+}

--- a/src/layouts/TabLayout/Tab.module.scss
+++ b/src/layouts/TabLayout/Tab.module.scss
@@ -5,7 +5,7 @@
   flex-direction: row;
   user-select: none;
   width: auto;
-  height: 2rem;
+  height: 2.5rem;
 }
 
 #secondEdge {
@@ -16,9 +16,9 @@
   background-color: styles.$default-background;
   display: flex;
   align-items: center;
-  margin: 0 -0.6px;
+  margin: 0 -15px;
   padding: 0.3rem 0;
-  height: fit-content;
+  height: 100%;
 }
 
 #label {

--- a/src/layouts/TabLayout/Tab.module.scss
+++ b/src/layouts/TabLayout/Tab.module.scss
@@ -1,0 +1,54 @@
+@use "@styles/styles";
+
+#wrapper {
+  display: flex;
+  flex-direction: row;
+  user-select: none;
+  width: auto;
+  height: 2rem;
+}
+
+#secondEdge {
+  transform: rotateY(180deg);
+}
+
+#content {
+  background-color: styles.$default-background;
+  display: flex;
+  align-items: center;
+  margin: 0 -0.6px;
+  padding: 0.3rem 0;
+  height: fit-content;
+}
+
+#label {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.4rem;
+
+  margin: 0 -0.7rem;
+  padding: 0.2rem 0.4rem;
+
+  background-color: #f2f4f5;
+  border-radius: 5rem;
+  z-index: 1;
+
+  #icon {
+    width: 100%;
+    aspect-ratio: 1/1;
+    color: styles.$title-text-color;
+  }
+
+  #icon > * {
+    width: 100%;
+    height: 100%;
+  }
+
+  #title {
+    font-size: 1rem;
+    font-weight: 500;
+    white-space: nowrap;
+    color: styles.$title-text-color;
+  }
+}

--- a/src/layouts/TabLayout/Tab.tsx
+++ b/src/layouts/TabLayout/Tab.tsx
@@ -1,0 +1,22 @@
+import styles from "@layouts/TabLayout/Tab.module.scss";
+import { TabEdge } from "@layouts/TabLayout/TabEdge";
+type Props = {
+  title: string;
+  icon?: React.ReactNode;
+  onClick: () => void;
+};
+
+export const Tab = ({ title, icon, onClick }: Props) => {
+  return (
+    <div id={styles.wrapper} onClick={onClick}>
+      <TabEdge id={styles.firstEdge} />
+      <div id={styles.content}>
+        <div id={styles.label}>
+          <div id={styles.icon}>{icon}</div>
+          <div id={styles.title}>{title}</div>
+        </div>
+      </div>
+      <TabEdge id={styles.secondEdge} />
+    </div>
+  );
+};

--- a/src/layouts/TabLayout/TabBar.module.scss
+++ b/src/layouts/TabLayout/TabBar.module.scss
@@ -14,10 +14,6 @@
   opacity: 70%;
 }
 
-#wrapper > *:nth-child(n + 2) {
-  //margin-left: -5rem;
-}
-
 #wrapper::-webkit-scrollbar {
   display: none;
 }

--- a/src/layouts/TabLayout/TabBar.module.scss
+++ b/src/layouts/TabLayout/TabBar.module.scss
@@ -1,0 +1,19 @@
+#wrapper {
+  display: flex;
+  flex-direction: row;
+  flex-shrink: 0;
+  align-items: flex-end;
+  width: 100%;
+  height: 2rem;
+  overflow-x: scroll;
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+#wrapper > *:nth-child(n + 2) {
+  //margin-left: -5rem;
+}
+
+#wrapper::-webkit-scrollbar {
+  display: none;
+}

--- a/src/layouts/TabLayout/TabBar.module.scss
+++ b/src/layouts/TabLayout/TabBar.module.scss
@@ -4,10 +4,14 @@
   flex-shrink: 0;
   align-items: flex-end;
   width: 100%;
-  height: 2rem;
+  height: auto;
   overflow-x: scroll;
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
+}
+
+.inactive {
+  opacity: 70%;
 }
 
 #wrapper > *:nth-child(n + 2) {

--- a/src/layouts/TabLayout/TabBar.tsx
+++ b/src/layouts/TabLayout/TabBar.tsx
@@ -1,0 +1,29 @@
+import styles from "@layouts/TabLayout/TabBar.module.scss";
+import { TabItem } from "@layouts/TabLayout/TabItem";
+import { Tab } from "@layouts/TabLayout/Tab";
+import React from "react";
+
+type Props = {
+  items: TabItem[];
+  onTabClick: (id: string) => void;
+};
+
+export const TabBar = ({ items, onTabClick }: Props) => {
+  return (
+    <div id={styles.wrapper}>
+      {items.map((item) => {
+        return (
+          <React.Fragment key={item.id}>
+            <Tab
+              title={item.name}
+              icon={item.icon}
+              onClick={() => {
+                onTabClick(item.id);
+              }}
+            ></Tab>
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/layouts/TabLayout/TabBar.tsx
+++ b/src/layouts/TabLayout/TabBar.tsx
@@ -6,14 +6,18 @@ import React from "react";
 type Props = {
   items: TabItem[];
   onTabClick: (id: string) => void;
+  visibleTabId: string;
 };
 
-export const TabBar = ({ items, onTabClick }: Props) => {
+export const TabBar = ({ items, onTabClick, visibleTabId }: Props) => {
   return (
     <div id={styles.wrapper}>
       {items.map((item) => {
         return (
-          <React.Fragment key={item.id}>
+          <div
+            key={item.id}
+            className={item.id != visibleTabId ? styles.inactive : ""}
+          >
             <Tab
               title={item.name}
               icon={item.icon}
@@ -21,7 +25,7 @@ export const TabBar = ({ items, onTabClick }: Props) => {
                 onTabClick(item.id);
               }}
             ></Tab>
-          </React.Fragment>
+          </div>
         );
       })}
     </div>

--- a/src/layouts/TabLayout/TabEdge.module.scss
+++ b/src/layouts/TabLayout/TabEdge.module.scss
@@ -1,0 +1,16 @@
+@use "@styles/styles";
+
+.tabEdge {
+  height: 100%;
+  aspect-ratio: 28.712425 / 29;
+  background-color: styles.$default-background;
+  @include styles.undraggable;
+
+  mask-image: url("src/public/svg/tab-edge.svg");
+  mask-repeat: no-repeat;
+  mask-size: contain;
+
+  -webkit-mask-image: url("src/public/svg/tab-edge.svg");
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+}

--- a/src/layouts/TabLayout/TabEdge.module.scss
+++ b/src/layouts/TabLayout/TabEdge.module.scss
@@ -4,13 +4,6 @@
   height: 100%;
   aspect-ratio: 28.712425 / 29;
   background-color: styles.$default-background;
+  border-top-left-radius: 50%;
   @include styles.undraggable;
-
-  mask-image: url("src/public/svg/tab-edge.svg");
-  mask-repeat: no-repeat;
-  mask-size: contain;
-
-  -webkit-mask-image: url("src/public/svg/tab-edge.svg");
-  -webkit-mask-repeat: no-repeat;
-  -webkit-mask-size: contain;
 }

--- a/src/layouts/TabLayout/TabEdge.tsx
+++ b/src/layouts/TabLayout/TabEdge.tsx
@@ -1,0 +1,9 @@
+import styles from "@layouts/TabLayout/TabEdge.module.scss";
+
+type Props = {
+  id?: string;
+};
+
+export const TabEdge = ({ id }: Props) => {
+  return <div id={id} className={styles.tabEdge} />;
+};

--- a/src/layouts/TabLayout/TabItem.ts
+++ b/src/layouts/TabLayout/TabItem.ts
@@ -1,0 +1,7 @@
+export type TabItem = {
+  id: string;
+  name: string;
+  //FIXME: cambiar a obligatorio cuando arregle el bug de aria-hidden
+  icon?: React.ReactNode;
+  component: React.ReactNode;
+};

--- a/src/layouts/TabLayout/TabLayout.module.scss
+++ b/src/layouts/TabLayout/TabLayout.module.scss
@@ -1,0 +1,34 @@
+@use "@styles/styles";
+
+#wrapper {
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+
+  filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.188));
+}
+
+#body {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-grow: 1;
+  background-color: styles.$default-background;
+
+  padding: 1rem;
+
+  border-top-right-radius: styles.$default-border-radius;
+  border-bottom-left-radius: styles.$default-border-radius;
+  border-bottom-right-radius: styles.$default-border-radius;
+}
+
+#componentWrapper {
+  width: 100%;
+  height: 100%;
+  border: 1px solid;
+  border-radius: styles.$default-border-radius;
+  overflow: hidden;
+}

--- a/src/layouts/TabLayout/TabLayout.module.scss
+++ b/src/layouts/TabLayout/TabLayout.module.scss
@@ -28,7 +28,5 @@
 #componentWrapper {
   width: 100%;
   height: 100%;
-  border: 1px solid;
-  border-radius: styles.$default-border-radius;
   overflow: hidden;
 }

--- a/src/layouts/TabLayout/TabLayout.tsx
+++ b/src/layouts/TabLayout/TabLayout.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import styles from "@layouts/TabLayout/TabLayout.module.scss";
+import React from "react";
+import { TabBar } from "@layouts/TabLayout/TabBar";
+import { TabItem } from "@layouts/TabLayout/TabItem";
+
+type Props = {
+  items: TabItem[];
+};
+
+export const TabLayout = ({ items }: Props) => {
+  let [visibleTab, setVisibleTab] = useState("");
+
+  function handleClick(id: string) {
+    setVisibleTab(id);
+  }
+
+  useEffect(() => {
+    if (items.length > 0) {
+      setVisibleTab(items[0].id);
+    }
+  }, []);
+
+  return (
+    <div id={styles.wrapper}>
+      <TabBar items={items} onTabClick={handleClick} />
+      <div id={styles.body}>
+        <div id={styles.componentWrapper}>
+          {items.map((item) => {
+            if (visibleTab == item.id) {
+              return (
+                <React.Fragment key={item.id}>{item.component}</React.Fragment>
+              );
+            }
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/layouts/TabLayout/TabLayout.tsx
+++ b/src/layouts/TabLayout/TabLayout.tsx
@@ -9,25 +9,29 @@ type Props = {
 };
 
 export const TabLayout = ({ items }: Props) => {
-  let [visibleTab, setVisibleTab] = useState("");
+  let [visibleTabId, setVisibleTabId] = useState("");
 
   function handleClick(id: string) {
-    setVisibleTab(id);
+    setVisibleTabId(id);
   }
 
   useEffect(() => {
     if (items.length > 0) {
-      setVisibleTab(items[0].id);
+      setVisibleTabId(items[0].id);
     }
   }, []);
 
   return (
     <div id={styles.wrapper}>
-      <TabBar items={items} onTabClick={handleClick} />
+      <TabBar
+        items={items}
+        onTabClick={handleClick}
+        visibleTabId={visibleTabId}
+      />
       <div id={styles.body}>
         <div id={styles.componentWrapper}>
           {items.map((item) => {
-            if (visibleTab == item.id) {
+            if (visibleTabId == item.id) {
               return (
                 <React.Fragment key={item.id}>{item.component}</React.Fragment>
               );

--- a/src/public/svg/tab-edge.svg
+++ b/src/public/svg/tab-edge.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="28.712425"
+   height="29"
+   viewBox="0 0 28.712425 29"
+   fill="none"
+   version="1.1"
+   id="svg23"
+   sodipodi:docname="Vector.svg"
+   inkscape:export-filename="..\Documents\repos-hyper\H8\Frontend-H8\src\tab_edge.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs27" />
+  <sodipodi:namedview
+     id="namedview25"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false" />
+  <path
+     d="M 28.712425,0 C 19.15374,2.5497509e-6 14.31895,4.3160345 12.5161,8.2142495 10.71325,12.112465 10.949335,11.61377 9.46774,14.7857 7.9861452,17.95763 3.69773,21.7602 2.59886,22.8801 1.5,24 0,27 0,29 h 28.712425 z"
+     fill="#000000"
+     id="path19"
+     sodipodi:nodetypes="czzcccc"
+     inkscape:export-filename="..\Documents\repos-hyper\H8\Frontend-H8\src\path19.svg"
+     inkscape:export-xdpi="300"
+     inkscape:export-ydpi="300" />
+</svg>

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,9 +1,11 @@
 $normal-font: Inter;
 $code-font: Consolas;
 $default-text-color: #40464f;
+$title-text-color: #4f5762;
 $default-background: #fdfdfd;
 $default-border-radius: 0.8rem;
 $default-font-size: 0.8rem;
+
 @mixin code-text {
   font-family: Consolas;
   font-size: $default-font-size;
@@ -14,6 +16,15 @@ $default-font-size: 0.8rem;
   font-family: $normal-font;
   font-size: $default-font-size;
   color: $default-text-color;
+}
+
+@mixin undraggable {
+  user-drag: none;
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-drag: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
 }
 
 //If it's only :root, font-size changes the base rem. If it's :root *, it affects everything, skipping inheritance.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
       "@mocks/*": ["mocks/*"],
       "@styles/*": ["styles/*"],
       "@layouts/*": ["layouts/*"],
-      "@pages/*": ["pages/*"]
+      "@pages/*": ["pages/*"],
+      "@public/*": ["public/*"]
     }
   },
   "include": ["src"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,8 @@ export default defineConfig({
       "@mocks": path.resolve(__dirname, "./src/mocks"),
       "@styles": path.resolve(__dirname, "./src/styles"),
       "@layouts": path.resolve(__dirname, "./src/layouts"),
-      "@pages": path.resolve(__dirname, "./src/pages")
+      "@public": path.resolve(__dirname, "./src/public"),
+      "@pages": path.resolve(__dirname, "./src/pages"),
     },
   },
 });


### PR DESCRIPTION
This PR adds the TabLayout, which allows you to switch between different tabs as demonstrated in the video. The title, icon and component of each tab are passed as parameters. Right now, the tab itself shows a weird disconnect with the div underneath: this must be related to the techcnique I'm using to display the custom curved edge. This will be fixed in future PRs.

[screen-capture (3).webm](https://user-images.githubusercontent.com/114338434/202998363-ab978645-25e1-4829-ac98-fdeb84e5d1f9.webm)
