### PR TITLE
[PR1] DEV-68 Refactored ReceiveTable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "^18.2.0",
         "react-icons": "^4.6.0",
         "react-redux": "^8.0.5",
+        "react-virtualized-auto-sizer": "^1.0.7",
         "react-window": "^1.8.8"
       },
       "devDependencies": {
@@ -28,6 +29,7 @@
         "@types/node": "^18.11.9",
         "@types/react": "^18.0.24",
         "@types/react-dom": "^18.0.8",
+        "@types/react-virtualized-auto-sizer": "^1.0.1",
         "@types/react-window": "^1.8.5",
         "@vitejs/plugin-react": "^2.2.0",
         "jsdom": "^20.0.2",
@@ -996,6 +998,15 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.8.tgz",
       "integrity": "sha512-C3GYO0HLaOkk9dDAz3Dl4sbe4AKUGTCfFIZsz3n/82dPNN8Du533HzKatDxeUYWu24wJgMP1xICqkWk1YOLOIw==",
       "devOptional": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-virtualized-auto-sizer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.1.tgz",
+      "integrity": "sha512-GH8sAnBEM5GV9LTeiz56r4ZhMOUSrP43tAQNSRVxNexDjcNKLCEtnxusAItg1owFUFE6k0NslV26gqVClVvong==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3315,6 +3326,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.7.tgz",
+      "integrity": "sha512-Mxi6lwOmjwIjC1X4gABXMJcKHsOo0xWl3E3ugOgufB8GJU+MqrtY35aBuvCYv/razQ1Vbp7h1gWJjGjoNN5pmA==",
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"
+      }
+    },
     "node_modules/react-window": {
       "version": "1.8.8",
       "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.8.tgz",
@@ -4760,6 +4783,15 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.8.tgz",
       "integrity": "sha512-C3GYO0HLaOkk9dDAz3Dl4sbe4AKUGTCfFIZsz3n/82dPNN8Du533HzKatDxeUYWu24wJgMP1xICqkWk1YOLOIw==",
       "devOptional": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-virtualized-auto-sizer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.1.tgz",
+      "integrity": "sha512-GH8sAnBEM5GV9LTeiz56r4ZhMOUSrP43tAQNSRVxNexDjcNKLCEtnxusAItg1owFUFE6k0NslV26gqVClVvong==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -6443,6 +6475,12 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true
+    },
+    "react-virtualized-auto-sizer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.7.tgz",
+      "integrity": "sha512-Mxi6lwOmjwIjC1X4gABXMJcKHsOo0xWl3E3ugOgufB8GJU+MqrtY35aBuvCYv/razQ1Vbp7h1gWJjGjoNN5pmA==",
+      "requires": {}
     },
     "react-window": {
       "version": "1.8.8",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.6.0",
     "react-redux": "^8.0.5",
+    "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8"
   },
   "devDependencies": {
@@ -30,6 +31,7 @@
     "@types/node": "^18.11.9",
     "@types/react": "^18.0.24",
     "@types/react-dom": "^18.0.8",
+    "@types/react-virtualized-auto-sizer": "^1.0.1",
     "@types/react-window": "^1.8.5",
     "@vitejs/plugin-react": "^2.2.0",
     "jsdom": "^20.0.2",

--- a/src/components/Caret/Caret.module.scss
+++ b/src/components/Caret/Caret.module.scss
@@ -1,0 +1,7 @@
+.wrapper {
+  width: min-content;
+  height: min-content;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/components/Caret/Caret.tsx
+++ b/src/components/Caret/Caret.tsx
@@ -1,0 +1,18 @@
+import styles from "@components/Caret/Caret.module.scss";
+import { BsFillCaretRightFill } from "react-icons/bs";
+type Props = {
+  isOpen: boolean;
+  onClick: () => void;
+};
+
+export const Caret = ({ isOpen, onClick }: Props) => {
+  return (
+    <div
+      className={styles.wrapper}
+      onClick={onClick}
+      style={{ transform: isOpen ? "rotate(90deg)" : "" }}
+    >
+      {<BsFillCaretRightFill />}
+    </div>
+  );
+};

--- a/src/components/ReceiveTable/BoardSection/BoardSection.module.scss
+++ b/src/components/ReceiveTable/BoardSection/BoardSection.module.scss
@@ -1,13 +1,39 @@
 @use "@styles/styles";
 
-.row {
-  border: 1px solid styles.$blue;
+.wrapper {
+  width: 100%;
+  display: grid;
+  grid-template-rows: min-content auto;
 
-  .name {
-    text-align: left;
-    padding-left: 1rem;
-    @include styles.default-text-2;
-    color: styles.$blue;
-    font-weight: 600;
+  border: 1px solid styles.$blue;
+  border-radius: styles.$default-border-radius;
+
+  .header {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    padding: 0.4rem 0;
+
+    & > :first-child {
+      margin: 0 0.3rem;
+      font-size: 1rem;
+      color: styles.$blue;
+    }
+    .name {
+      text-align: left;
+      @include styles.default-text-2;
+      color: styles.$blue;
+      font-weight: 600;
+    }
+  }
+
+  .packets {
+    width: 100%;
+    height: 40rem;
+
+    display: flex;
+    flex-direction: column;
+
+    border-top: styles.$default-border-width solid styles.$blue;
   }
 }

--- a/src/components/ReceiveTable/BoardSection/BoardSection.tsx
+++ b/src/components/ReceiveTable/BoardSection/BoardSection.tsx
@@ -1,24 +1,67 @@
 import styles from "@components/ReceiveTable/BoardSection/BoardSection.module.scss";
 import { Board } from "@models/PodData/Board";
+import { Caret } from "@components/Caret/Caret";
 import PacketRow from "@components/ReceiveTable/PacketRow/PacketRow";
-import { memo } from "react";
+import { memo, useState } from "react";
+import { VariableSizeList } from "react-window";
+import AutoSizer from "react-virtualized-auto-sizer";
 
 type Props = {
   board: Board;
+  scrollContainer: HTMLDivElement;
 };
 
-const BoardSection = ({ board }: Props) => {
+const BoardSection = ({ board, scrollContainer }: Props) => {
+  let [isVisible, setIsVisible] = useState(true);
+  let packetArr = Object.values(board.packets);
   return (
-    <>
-      <tr className={styles.row}>
-        <td className={styles.name} colSpan={5}>
-          {board.name}
-        </td>
-      </tr>
-      {Object.values(board.packets).map((packet) => {
-        return <PacketRow key={packet.id} packet={packet}></PacketRow>;
-      })}
-    </>
+    <div className={styles.wrapper}>
+      <div className={styles.header}>
+        <Caret
+          isOpen={isVisible}
+          onClick={() => {
+            setIsVisible((prevValue) => {
+              return !prevValue;
+            });
+          }}
+        />
+        {<div className={styles.name}>{board.name}</div>}
+      </div>
+      {isVisible && (
+        <div className={styles.packets}>
+          <AutoSizer>
+            {({ width, height }) => {
+              return (
+                <VariableSizeList
+                  innerElementType={"div"}
+                  itemData={packetArr}
+                  itemCount={packetArr.length}
+                  itemSize={(index) => {
+                    return (
+                      Object.keys(packetArr[index].measurements).length * 30 +
+                      30
+                    );
+                  }}
+                  width={width}
+                  height={height}
+                >
+                  {({ data, index, style }) => {
+                    return (
+                      <PacketRow
+                        key={data[index].id}
+                        packet={data[index]}
+                        style={style}
+                        scrollContainer={scrollContainer}
+                      ></PacketRow>
+                    );
+                  }}
+                </VariableSizeList>
+              );
+            }}
+          </AutoSizer>
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/components/ReceiveTable/Headers/Headers.module.scss
+++ b/src/components/ReceiveTable/Headers/Headers.module.scss
@@ -3,22 +3,26 @@
 #wrapper {
   border: 1px solid styles.$blue;
   border-radius: styles.$default-border-radius;
-  border: none;
   overflow: hidden;
   position: sticky;
   top: 0;
+  flex-shrink: 0;
 
   width: 100%;
+  z-index: 1;
 
   > * {
     padding: 0.5rem 0.5rem;
 
     @include styles.default-text-2;
     background-color: #bad6ff;
-    outline: 1px solid styles.transparent(styles.$blue, 0);
     color: styles.$blue;
     font-weight: 600;
     white-space: nowrap;
     text-align: center;
+  }
+
+  > *:nth-child(n + 2) {
+    border-left: 1px solid styles.$blue;
   }
 }

--- a/src/components/ReceiveTable/Headers/Headers.module.scss
+++ b/src/components/ReceiveTable/Headers/Headers.module.scss
@@ -1,15 +1,24 @@
 @use "@styles/styles";
 
-#headers th {
+#wrapper {
+  border: 1px solid styles.$blue;
+  border-radius: styles.$default-border-radius;
+  border: none;
+  overflow: hidden;
   position: sticky;
   top: 0;
 
-  min-width: 3rem;
-  padding: 0.5rem 0.5rem;
-  @include styles.default-text-2;
-  background-color: #bad6ff;
-  outline: 1px solid styles.$blue;
-  color: styles.$blue;
-  font-weight: 600;
-  white-space: nowrap;
+  width: 100%;
+
+  > * {
+    padding: 0.5rem 0.5rem;
+
+    @include styles.default-text-2;
+    background-color: #bad6ff;
+    outline: 1px solid styles.transparent(styles.$blue, 0);
+    color: styles.$blue;
+    font-weight: 600;
+    white-space: nowrap;
+    text-align: center;
+  }
 }

--- a/src/components/ReceiveTable/Headers/Headers.tsx
+++ b/src/components/ReceiveTable/Headers/Headers.tsx
@@ -1,14 +1,13 @@
 import styles from "@components/ReceiveTable/Headers/Headers.module.scss";
+import "@components/ReceiveTable/SharedStyles.scss";
 export const Headers = () => {
   return (
-    <thead id={styles.headers}>
-      <tr>
-        <th>ID</th>
-        <th>NAME</th>
-        <th>HEX VALUE</th>
-        <th>COUNT</th>
-        <th>CYCLE TIME</th>
-      </tr>
-    </thead>
+    <div id={styles.wrapper} className="tableRow">
+      <div>ID</div>
+      <div>NAME</div>
+      <div>HEX VALUE</div>
+      <div>COUNT</div>
+      <div>CYCLE TIME</div>
+    </div>
   );
 };

--- a/src/components/ReceiveTable/MeasurementRow/MeasurementRow.module.scss
+++ b/src/components/ReceiveTable/MeasurementRow/MeasurementRow.module.scss
@@ -1,9 +1,10 @@
 @use "@styles/styles";
 
-.measurementWrapper {
-  @include styles.code-text;
+.wrapper {
+  width: 100%;
   display: flex;
   flex-direction: row;
   gap: 1rem;
   padding: 0 1rem;
+  @include styles.code-text;
 }

--- a/src/components/ReceiveTable/MeasurementRow/MeasurementRow.tsx
+++ b/src/components/ReceiveTable/MeasurementRow/MeasurementRow.tsx
@@ -6,14 +6,10 @@ type Props = {
 
 export const MeasurementRow = ({ measurement }: Props) => {
   return (
-    <tr>
-      <td colSpan={5}>
-        <div className={styles.measurementWrapper}>
-          <div>{measurement.name}</div>
-          <div>{measurement.value}</div>
-          <div>{measurement.units}</div>
-        </div>
-      </td>
-    </tr>
+    <div className={styles.wrapper}>
+      <div>{measurement.name}</div>
+      <div>{measurement.value}</div>
+      <div>{measurement.units}</div>
+    </div>
   );
 };

--- a/src/components/ReceiveTable/PacketRow/PacketRow.module.scss
+++ b/src/components/ReceiveTable/PacketRow/PacketRow.module.scss
@@ -1,8 +1,24 @@
 @use "@styles/styles";
-.packetRow {
-  @include styles.code-text;
+
+.wrapper {
+  display: grid;
+  grid-template-rows: min-content auto;
+  // content-visibility: auto;
 }
 
-.packetRow td {
-  padding: 0 1rem;
+.packetInfo {
+  @include styles.code-text;
+
+  > * {
+    border: 1px solid lightgray;
+  }
+}
+
+.measurements {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  > * {
+    margin: 0.5rem 0;
+  }
 }

--- a/src/components/ReceiveTable/PacketRow/PacketRow.module.scss
+++ b/src/components/ReceiveTable/PacketRow/PacketRow.module.scss
@@ -10,6 +10,7 @@
 
   > * {
     border: 1px solid lightgray;
+    margin: -1px 0 0 -1px;
   }
 }
 

--- a/src/components/ReceiveTable/PacketRow/PacketRow.module.scss
+++ b/src/components/ReceiveTable/PacketRow/PacketRow.module.scss
@@ -3,7 +3,6 @@
 .wrapper {
   display: grid;
   grid-template-rows: min-content auto;
-  // content-visibility: auto;
 }
 
 .packetInfo {

--- a/src/components/ReceiveTable/PacketRow/PacketRow.tsx
+++ b/src/components/ReceiveTable/PacketRow/PacketRow.tsx
@@ -1,31 +1,36 @@
 import { Packet } from "@models/PodData/Packet";
 import styles from "@components/ReceiveTable/PacketRow/PacketRow.module.scss";
 import { MeasurementRow } from "@components/ReceiveTable/MeasurementRow/MeasurementRow";
-import { memo } from "react";
-
+import { memo, useRef, useEffect } from "react";
 type Props = {
   packet: Packet;
+  scrollContainer: HTMLDivElement;
+  style: React.CSSProperties;
 };
 
-const PacketRow = ({ packet }: Props) => {
+const PacketRow = ({ packet, scrollContainer, style }: Props) => {
+  let packetContainer = useRef<HTMLDivElement>(null);
+
   return (
-    <>
-      <tr className={styles.packetRow}>
-        <td>{packet.id}</td>
-        <td>{packet.name}</td>
-        <td>{packet.hexValue}</td>
-        <td>{packet.count}</td>
-        <td>{packet.cycleTime}</td>
-      </tr>
-      {Object.values(packet.measurements).map((measurement) => {
-        return (
-          <MeasurementRow
-            key={measurement.name}
-            measurement={measurement}
-          ></MeasurementRow>
-        );
-      })}
-    </>
+    <div className={styles.wrapper} ref={packetContainer} style={style}>
+      <div className={`${styles.packetInfo} tableRow`}>
+        <div>{packet.id}</div>
+        <div>{packet.name}</div>
+        <div>{packet.hexValue}</div>
+        <div>{packet.count}</div>
+        <div>{packet.cycleTime}</div>
+      </div>
+      <div className={styles.measurements}>
+        {Object.values(packet.measurements).map((measurement) => {
+          return (
+            <MeasurementRow
+              key={measurement.name}
+              measurement={measurement}
+            ></MeasurementRow>
+          );
+        })}
+      </div>
+    </div>
   );
 };
 

--- a/src/components/ReceiveTable/ReceiveTable.module.scss
+++ b/src/components/ReceiveTable/ReceiveTable.module.scss
@@ -4,14 +4,13 @@
 //FIXME: no border between last measurement and next board header
 
 #wrapper {
-  //border: 1px solid styles.$blue;
   background-color: styles.$default-background;
   width: 100%;
   height: 100%;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 1rem;
 }
 
 .boards {

--- a/src/components/ReceiveTable/ReceiveTable.module.scss
+++ b/src/components/ReceiveTable/ReceiveTable.module.scss
@@ -1,41 +1,31 @@
 @use "@styles/styles";
 
+//FIXME: when width small, cells misalign
+//FIXME: no border between last measurement and next board header
+
 #wrapper {
-  border: 1px solid styles.$blue;
-  border-radius: styles.$default-border-radius;
+  //border: 1px solid styles.$blue;
   background-color: styles.$default-background;
   width: 100%;
   height: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-#table {
-  width: 100%;
-  height: 100%;
-  border-style: hidden;
-  text-align: center;
-}
-
-#table,
-#table th,
-#table td {
-  border-collapse: collapse;
-  height: fit-content;
-  padding: 0.25rem;
-}
-
-#table td {
-  border: 1px solid lightgray;
-}
-
-.boardRow {
-  border: 1px solid styles.$blue;
-
+.boards {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 1rem;
   .boardName {
     text-align: left;
     padding-left: 1rem;
     @include styles.default-text-2;
     color: styles.$blue;
     font-weight: 600;
+    //FIXME: blue border is under gray border from packet
+    border: 1px solid styles.$blue;
   }
 }

--- a/src/components/ReceiveTable/ReceiveTable.tsx
+++ b/src/components/ReceiveTable/ReceiveTable.tsx
@@ -1,4 +1,5 @@
 import { useSelector } from "react-redux";
+import { useRef } from "react";
 import { RootState } from "store";
 import styles from "@components/ReceiveTable/ReceiveTable.module.scss";
 import { Headers } from "@components/ReceiveTable/Headers/Headers";
@@ -6,16 +7,22 @@ import BoardSection from "@components/ReceiveTable/BoardSection/BoardSection";
 
 export const ReceiveTable = () => {
   const boards = useSelector((state: RootState) => state.podData.boards);
+  const boardsWrapper = useRef<HTMLDivElement>(null);
+
   return (
     <div id={styles.wrapper}>
-      <table id={styles.table}>
-        <Headers />
-        <tbody id={styles.tableBody}>
-          {Object.values(boards).map((board) => {
-            return <BoardSection key={board.name} board={board} />;
-          })}
-        </tbody>
-      </table>
+      <Headers />
+      <div className={styles.boards} ref={boardsWrapper}>
+        {Object.values(boards).map((board) => {
+          return (
+            <BoardSection
+              key={board.name}
+              board={board}
+              scrollContainer={boardsWrapper.current!}
+            />
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/src/components/ReceiveTable/SharedStyles.scss
+++ b/src/components/ReceiveTable/SharedStyles.scss
@@ -4,9 +4,7 @@
   grid-template-rows: auto;
 
   > * {
-    margin: -1px 0 0 -1px;
     padding: 0.3rem;
-
     text-align: center;
   }
 }

--- a/src/components/ReceiveTable/SharedStyles.scss
+++ b/src/components/ReceiveTable/SharedStyles.scss
@@ -1,0 +1,12 @@
+.tableRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+  grid-template-rows: auto;
+
+  > * {
+    margin: -1px 0 0 -1px;
+    padding: 0.3rem;
+
+    text-align: center;
+  }
+}

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -13,11 +13,11 @@ export const HomePage = () => {
         <SplitLayout
           components={[
             <ReceiveColumn />,
-            <TransmitColumn />,
-            <MessagesColumn />,
+            // <TransmitColumn />,
+            // <MessagesColumn />,
           ]}
           direction={Direction.HORIZONTAL}
-          initialPortions={[0.333, 0.333, 0.333]}
+          initialPortions={[1]}
         ></SplitLayout>
       </div>
     </div>

--- a/src/pages/HomePage/ReceiveColumn/ReceiveColumn.tsx
+++ b/src/pages/HomePage/ReceiveColumn/ReceiveColumn.tsx
@@ -16,12 +16,12 @@ export const ReceiveColumn = () => {
           icon: <HiInboxArrowDown />,
           component: <ReceiveTable />,
         },
-        {
-          id: nanoid(),
-          name: "Charts",
-          icon: <BiLineChart />,
-          component: <ChartMenu />,
-        },
+        // {
+        //   id: nanoid(),
+        //   name: "Charts",
+        //   icon: <BiLineChart />,
+        //   component: <ChartMenu />,
+        // },
       ]}
     ></TabLayout>
   );

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $normal-font: Inter;
 //$code-font: Cascadia Code;
 //$code-font: Cascadia Mono;
@@ -10,6 +12,11 @@ $orange: #f28d30;
 $blue: #317ae7;
 $default-border-radius: 0.2rem;
 $default-font-size: 0.8rem;
+$default-border-width: 1px;
+
+@function transparent($color, $transparency) {
+  @return color.adjust($color, $alpha: $transparency);
+}
 
 @mixin code-text {
   font-family: $code-font;


### PR DESCRIPTION
This PR introduces a major refactor to the ReceiveTable Component. To be able to handle the load of packets, I've used a library called `react-window`. When you have a very long list but only some elements are visible, you can use this library to only create the visible components, meaning that all **of the unseen items are not created**, therefore not updated when nwe pakcet updates arrive, thus increasing performance.
[screen-capture (7).webm](https://user-images.githubusercontent.com/114338434/206741083-9b63497b-9ce1-48f8-a4c6-80851d8b0894.webm)

The `VariableSizeList` component provided by the `react-window` library is used in `BoardSection`: 

![image](https://user-images.githubusercontent.com/114338434/206741282-21b186d5-9bf2-4c23-bacf-80e046086465.png)

I've also used `AutoSizer`, which is an additional component that's needed so the list is 100% width of the parent. Both react-window and autosizer are extracts from a bigger library called react-virtualized, which provides a multitude of components that allow you to increase performance in the way I described earlier. I you are interested in how react-window works, this might help: 
![image](https://user-images.githubusercontent.com/114338434/206747497-90ce38ff-dde9-4ccc-ad13-276be632d09e.png)

Basically, with the parameter of total size of the list, size per item, and position of scroll, the `VariableSizeList` is able to determine wich components should be rendered and where. Then it uses absolute positioning to place each item in the correct position. Everytime the scroll event is fired, all this calculation are done again.

Other major change is that **instead of using the HTML table element, I've used flex and grid layout**. This simplifies the component and makes it compatible with `react-window`. If you don't understand this last reason, ask me if interested.
