### PR TITLE
[PR1] DEV-86: Changes in MessageList CSS

### DIFF
--- a/src/components/ConnectionsTable/ConnectionList/ConnectionList.module.scss
+++ b/src/components/ConnectionsTable/ConnectionList/ConnectionList.module.scss
@@ -1,14 +1,7 @@
 @use "@styles/styles.scss";
 
 .wrapper {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-
-  width: 100%;
-  height: 100%;
   min-height: fit-content;
-  overflow-y: auto;
   background-color: styles.$default-background;
 }
 

--- a/src/components/ConnectionsTable/ConnectionsTable.module.scss
+++ b/src/components/ConnectionsTable/ConnectionsTable.module.scss
@@ -1,4 +1,7 @@
 .wrapper {
-  display: grid;
-  grid-template-rows: 1fr 1fr;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
 }

--- a/src/components/MessageLogger/FaultsAndWarningList/FaultsAndWarningList.module.scss
+++ b/src/components/MessageLogger/FaultsAndWarningList/FaultsAndWarningList.module.scss
@@ -8,5 +8,5 @@
   background-color: styles.$default-background;
   overflow-x: hidden;
   overflow-y: hidden;
-  gap: 1rem;
+  gap: 0.5rem;
 }

--- a/src/components/MessageLogger/MessageItem/MessageItem.module.scss
+++ b/src/components/MessageLogger/MessageItem/MessageItem.module.scss
@@ -3,8 +3,8 @@
 .lineMsg {
   width: 100%;
   display: grid;
-  grid-template-columns: 1.2rem auto 1fr 2em;
-  grid-template-areas: "caret id description counter";
+  grid-template-columns: 1.2rem auto auto 1fr;
+  grid-template-areas: "caret id counter description";
   text-align: left;
   white-space: nowrap;
   align-items: center;
@@ -26,12 +26,16 @@
 .counter {
   grid-area: counter;
   justify-self: center;
+  margin-left: 0.1rem;
+  margin-right: 0.1rem;
 }
 
 .open {
   white-space: normal;
+  align-items: baseline;
 }
 
 .close {
   white-space: nowrap;
+  align-items: center;
 }

--- a/src/components/MessageLogger/MessageItem/MessageItem.module.scss
+++ b/src/components/MessageLogger/MessageItem/MessageItem.module.scss
@@ -4,7 +4,10 @@
   width: 100%;
   display: grid;
   grid-template-columns: 1.2rem auto auto 1fr;
-  grid-template-areas: "caret id counter description";
+  grid-template-rows: 0.9rem auto;
+  grid-template-areas:
+    "caret id counter description"
+    ". . . description";
   text-align: left;
   white-space: nowrap;
   align-items: center;
@@ -32,10 +35,4 @@
 
 .open {
   white-space: normal;
-  align-items: baseline;
-}
-
-.close {
-  white-space: nowrap;
-  align-items: center;
 }

--- a/src/components/MessageLogger/MessageItem/MessageItem.module.scss
+++ b/src/components/MessageLogger/MessageItem/MessageItem.module.scss
@@ -4,7 +4,7 @@
   width: 100%;
   display: grid;
   grid-template-columns: 1.2rem auto auto 1fr;
-  grid-template-rows: 0.9rem auto;
+  grid-template-rows: auto auto;
   grid-template-areas:
     "caret id counter description"
     ". . . description";

--- a/src/components/MessageLogger/MessageItem/MessageItem.tsx
+++ b/src/components/MessageLogger/MessageItem/MessageItem.tsx
@@ -47,7 +47,7 @@ export const MessageItem = ({ message, count, color }: Props) => {
   return (
     <li
       ref={wrapperRef}
-      className={`${styles.lineMsg} ${isOpen ? styles.open : styles.close}`}
+      className={`${styles.lineMsg} ${isOpen ? styles.open : ""}`}
       key={message.id}
       style={{
         backgroundColor: hslColorToString(getSofterHSLColor(color, 48)),

--- a/src/components/MessageLogger/MessageItem/MessageItem.tsx
+++ b/src/components/MessageLogger/MessageItem/MessageItem.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import styles from "@components/MessageLogger/MessageItem/MessageItem.module.scss";
 import { Message } from "@adapters/Message";
 import { Counter } from "@components/MessageLogger/Counter/Counter";
@@ -31,6 +31,10 @@ export const MessageItem = ({ message, count, color }: Props) => {
 
     return overflowing;
   }
+
+  useLayoutEffect(() => {
+    setIsOverflowing(checkOverflow(descriptionRef.current!));
+  }, []);
 
   useEffect(() => {
     resizeObserver.current.observe(descriptionRef.current!);

--- a/src/components/MessageLogger/MessageList/MessageList.module.scss
+++ b/src/components/MessageLogger/MessageList/MessageList.module.scss
@@ -2,11 +2,12 @@
 
 .messagesList {
   width: 100%;
-  height: 100%;
+  height: fit-content;
   overflow-x: hidden;
   overflow-y: auto;
   background-color: styles.$default-background;
   @include styles.code-text;
+  border-radius: styles.$default-border-radius;
 
   > *:not(:last-child) {
     border-bottom: 1px solid black;


### PR DESCRIPTION
Change in the distribution of messageItem. Use of useLayouteffect so that the first rendering of messageItem is directly with the counter visibility calculated, so that there are no initial momentary bugs. Id and counter at the top of the cell when the message is displayed. Added border-radius too