### PR TITLE
[PR1] DEV-91 Refactored SplitLayout

### DIFF
--- a/src/layouts/SplitLayout/Component/Component.module.scss
+++ b/src/layouts/SplitLayout/Component/Component.module.scss
@@ -1,0 +1,4 @@
+.wrapper {
+    min-width: 0;
+    min-height: 0;
+}

--- a/src/layouts/SplitLayout/Component/Component.tsx
+++ b/src/layouts/SplitLayout/Component/Component.tsx
@@ -2,15 +2,15 @@ import styles from "@layouts/SplitLayout/Component/Component.module.scss";
 
 type Props = {
     component: React.ReactNode;
-    normalizedPortion: number;
+    normalizedLength: number;
 };
 
-export const Component = ({ component, normalizedPortion }: Props) => {
+export const Component = ({ component, normalizedLength }: Props) => {
     return (
         <div
             className={styles.wrapper}
             style={{
-                flexBasis: `${normalizedPortion * 100}%`,
+                flexBasis: `${normalizedLength * 100}%`,
             }}
         >
             {component}

--- a/src/layouts/SplitLayout/Component/Component.tsx
+++ b/src/layouts/SplitLayout/Component/Component.tsx
@@ -1,0 +1,19 @@
+import styles from "@layouts/SplitLayout/Component/Component.module.scss";
+
+type Props = {
+    component: React.ReactNode;
+    normalizedPortion: number;
+};
+
+export const Component = ({ component, normalizedPortion }: Props) => {
+    return (
+        <div
+            className={styles.wrapper}
+            style={{
+                flexBasis: `${normalizedPortion * 100}%`,
+            }}
+        >
+            {component}
+        </div>
+    );
+};

--- a/src/layouts/SplitLayout/Direction.ts
+++ b/src/layouts/SplitLayout/Direction.ts
@@ -1,0 +1,4 @@
+export enum Direction {
+    VERTICAL,
+    HORIZONTAL,
+}

--- a/src/layouts/SplitLayout/Separator/Separator.module.scss
+++ b/src/layouts/SplitLayout/Separator/Separator.module.scss
@@ -1,0 +1,20 @@
+@use "@styles/styles";
+
+.wrapper {
+    flex: 0 1 0rem;
+    padding: 0.5rem;
+    .line {
+        width: 100%;
+        height: 100%;
+        padding: 1px;
+        border-radius: 1rem;
+        background-color: none;
+        transition: styles.$background-color-transition;
+    }
+
+    &:hover {
+        .line {
+            background-color: styles.lightness(styles.$background-color, -12%);
+        }
+    }
+}

--- a/src/layouts/SplitLayout/Separator/Separator.tsx
+++ b/src/layouts/SplitLayout/Separator/Separator.tsx
@@ -1,0 +1,30 @@
+import { Direction } from "@layouts/SplitLayout/Direction";
+import styles from "@layouts/SplitLayout/Separator/Separator.module.scss";
+import React from "react";
+
+type Props = {
+    index: number;
+    direction: Direction;
+    handleSeparatorMouseDown: (index: number, ev: React.MouseEvent) => void;
+};
+
+export const Separator = ({
+    index,
+    direction,
+    handleSeparatorMouseDown,
+}: Props) => {
+    return (
+        <div
+            className={styles.wrapper}
+            style={{
+                cursor:
+                    direction == Direction.HORIZONTAL ? "e-resize" : "n-resize",
+            }}
+            onMouseDown={(ev) => {
+                handleSeparatorMouseDown(index, ev);
+            }}
+        >
+            <div className={styles.line}></div>
+        </div>
+    );
+};

--- a/src/layouts/SplitLayout/SplitLayout.module.scss
+++ b/src/layouts/SplitLayout/SplitLayout.module.scss
@@ -1,25 +1,6 @@
-@use "@styles/styles";
-
-#wrapper {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: space-between;
-}
-
-#wrapper > .componentWrapper {
-  min-width: 0;
-  min-height: 0;
-}
-
-.separator {
-  flex: 0 1 0rem;
-  padding: 1rem;
-  .line {
+.wrapper {
     width: 100%;
     height: 100%;
-    border: 1px solid #a7a7a7;
-    border-radius: 1rem;
-    padding: 1px;
-  }
+    display: flex;
+    justify-content: space-between;
 }

--- a/src/layouts/SplitLayout/SplitLayout.tsx
+++ b/src/layouts/SplitLayout/SplitLayout.tsx
@@ -1,151 +1,50 @@
 import React from "react";
 import styles from "@layouts/SplitLayout/SplitLayout.module.scss";
-import {
-  useState,
-  useEffect,
-  useRef,
-  MouseEvent as ReactMouseEvent,
-} from "react";
+import { useSplitLayoutHandler } from "@layouts/SplitLayout/useSplitLayoutHandler";
+import { Component } from "@layouts/SplitLayout/Component/Component";
+import { Separator } from "@layouts/SplitLayout/Separator/Separator";
+import { Direction } from "@layouts/SplitLayout/Direction";
+
 type Props = {
-  components: React.ReactNode[];
-  direction?: Direction;
-  initialPortions?: number[];
+    components: React.ReactNode[];
+    minSizes: number[];
+    direction?: Direction;
 };
 
-export enum Direction {
-  VERTICAL,
-  HORIZONTAL,
-}
-
 export const SplitLayout = ({
-  components,
-  direction = Direction.HORIZONTAL,
-  initialPortions,
+    components,
+    minSizes,
+    direction = Direction.HORIZONTAL,
 }: Props) => {
-  let [normalizedPortions, setNormalizedPortions] = useState<number[]>([]);
-  let mousePos = useRef([0, 0]);
-  let wrapperRef = useRef<HTMLDivElement>(null);
-  let separatorRef = useRef<HTMLDivElement>(null);
-  let targetElements = useRef([
-    { index: 0, initialSize: 0 },
-    { index: 1, initialSize: 0 },
-  ]);
-
-  useEffect(() => {
-    let portions;
-
-    if (initialPortions) {
-      portions = initialPortions;
-    } else {
-      let defaultFraction = 1 / components.length;
-      portions = new Array<number>(components.length).fill(defaultFraction);
-    }
-
-    setNormalizedPortions(portions);
-  }, []);
-
-  function handleSeparatorMouseDown(
-    ev: ReactMouseEvent<HTMLDivElement>,
-    index: number
-  ) {
-    ev.preventDefault();
-    mousePos.current = [ev.clientX, ev.clientY];
-    targetElements.current = [
-      { index: index, initialSize: normalizedPortions[index] },
-      { index: index + 1, initialSize: normalizedPortions[index + 1] },
-    ];
-    document.addEventListener("mousemove", handleDocumentMove);
-    document.addEventListener("mouseup", handleDocumentMouseUp);
-  }
-
-  function handleDocumentMouseUp(ev: MouseEvent) {
-    ev.preventDefault();
-    document.removeEventListener("mousemove", handleDocumentMove);
-    document.removeEventListener("mouseup", handleDocumentMouseUp);
-  }
-
-  function handleDocumentMove(ev: MouseEvent) {
-    ev.preventDefault();
-    let normalizedDisplacement = getNormalizedDisplacement(
-      getMouseDisplacement(ev)
+    const [normalizedPortions, handleSeparatorMouseDown] =
+        useSplitLayoutHandler(components.length, minSizes, direction);
+    return (
+        <div
+            className={styles.wrapper}
+            style={{
+                flexDirection:
+                    direction == Direction.HORIZONTAL ? "row" : "column",
+            }}
+        >
+            {components.map((component, index) => {
+                return (
+                    <React.Fragment key={index}>
+                        <Component
+                            component={component}
+                            normalizedPortion={normalizedPortions[index]}
+                        />
+                        {index < components.length - 1 && (
+                            <Separator
+                                index={index}
+                                direction={direction}
+                                handleSeparatorMouseDown={
+                                    handleSeparatorMouseDown
+                                }
+                            />
+                        )}
+                    </React.Fragment>
+                );
+            })}
+        </div>
     );
-    setNormalizedPortions((prevPortions) => {
-      return getNormalizedPortions(prevPortions, normalizedDisplacement);
-    });
-  }
-
-  function getMouseDisplacement(ev: MouseEvent): number {
-    if (direction == Direction.HORIZONTAL) {
-      return ev.clientX - mousePos.current[0];
-    } else {
-      return ev.clientY - mousePos.current[1];
-    }
-  }
-
-  function getNormalizedDisplacement(screenDisplacement: number): number {
-    let wrapperLength = getElementLength(wrapperRef.current!);
-    let wrapperLengthWithoutSeparators =
-      wrapperLength -
-      getElementLength(separatorRef.current!) * (normalizedPortions.length - 1);
-    return screenDisplacement / wrapperLengthWithoutSeparators;
-  }
-
-  function getElementLength(element: HTMLElement): number {
-    let rect = element.getBoundingClientRect();
-    if (direction == Direction.HORIZONTAL) {
-      return rect.width;
-    } else {
-      return rect.height;
-    }
-  }
-
-  function getNormalizedPortions(
-    prevFractions: number[],
-    normalizedDisplacement: number
-  ) {
-    let newFractions = [...prevFractions];
-    newFractions[targetElements.current[0].index] =
-      targetElements.current[0].initialSize + normalizedDisplacement;
-    newFractions[targetElements.current[1].index] =
-      targetElements.current[1].initialSize - normalizedDisplacement;
-    return newFractions;
-  }
-
-  return (
-    <div
-      id={styles.wrapper}
-      ref={wrapperRef}
-      style={{
-        flexDirection: direction == Direction.HORIZONTAL ? "row" : "column",
-      }}
-    >
-      {components.map((component, index, arr) => {
-        return (
-          <React.Fragment key={index}>
-            <div
-              className={styles.componentWrapper}
-              style={{ flexBasis: `${normalizedPortions[index] * 100}%` }}
-            >
-              {component}
-            </div>
-            {index < arr.length - 1 && (
-              <div
-                ref={separatorRef}
-                className={styles.separator}
-                style={{
-                  cursor:
-                    direction == Direction.HORIZONTAL ? "e-resize" : "n-resize",
-                }}
-                onMouseDown={(ev) => {
-                  handleSeparatorMouseDown(ev, index);
-                }}
-              >
-                <div className={styles.line}></div>
-              </div>
-            )}
-          </React.Fragment>
-        );
-      })}
-    </div>
-  );
 };

--- a/src/layouts/SplitLayout/SplitLayout.tsx
+++ b/src/layouts/SplitLayout/SplitLayout.tsx
@@ -16,8 +16,11 @@ export const SplitLayout = ({
     minSizes,
     direction = Direction.HORIZONTAL,
 }: Props) => {
-    const [normalizedPortions, handleSeparatorMouseDown] =
-        useSplitLayoutHandler(components.length, minSizes, direction);
+    const [splitElements, handleSeparatorMouseDown] = useSplitLayoutHandler(
+        components.length,
+        minSizes,
+        direction
+    );
     return (
         <div
             className={styles.wrapper}
@@ -31,7 +34,7 @@ export const SplitLayout = ({
                     <React.Fragment key={index}>
                         <Component
                             component={component}
-                            normalizedPortion={normalizedPortions[index]}
+                            normalizedLength={splitElements[index].length}
                         />
                         {index < components.length - 1 && (
                             <Separator

--- a/src/layouts/SplitLayout/SplitLayoutEventHandler.ts
+++ b/src/layouts/SplitLayout/SplitLayoutEventHandler.ts
@@ -1,0 +1,30 @@
+export class SplitLayoutEventHandler {
+    public onSeparatorMouseDown: (
+        separatorIndex: number,
+        ev: React.MouseEvent
+    ) => void = () => {};
+
+    public onSeparatorMove: (clientX: number, clientY: number) => void =
+        () => {};
+
+    public handleSeperatorMouseDown = (
+        separatorIndex: number,
+        ev: React.MouseEvent
+    ) => {
+        ev.preventDefault();
+        this.onSeparatorMouseDown(separatorIndex, ev);
+        document.addEventListener("mousemove", this.handleDocumentMove);
+        document.addEventListener("mouseup", this.handleDocumentMouseUp);
+    };
+
+    private handleDocumentMove = (ev: MouseEvent) => {
+        ev.preventDefault();
+        this.onSeparatorMove(ev.clientX, ev.clientY);
+    };
+
+    private handleDocumentMouseUp = (ev: MouseEvent) => {
+        ev.preventDefault();
+        document.removeEventListener("mousemove", this.handleDocumentMove);
+        document.removeEventListener("mouseup", this.handleDocumentMouseUp);
+    };
+}

--- a/src/layouts/SplitLayout/useSplitLayoutHandler.ts
+++ b/src/layouts/SplitLayout/useSplitLayoutHandler.ts
@@ -1,0 +1,249 @@
+import {
+    useState,
+    useEffect,
+    useRef,
+    MouseEvent as ReactMouseEvent,
+} from "react";
+
+import { SplitLayoutEventHandler } from "@layouts/SplitLayout/SplitLayoutEventHandler";
+import { iterateFrom, iterateFromReverse } from "@utils/array";
+import { Direction } from "@layouts/SplitLayout/Direction";
+
+type Size = {
+    width: number;
+    height: number;
+};
+
+function getElementSize(element: HTMLElement): Size {
+    let rect = element.getBoundingClientRect();
+    return { width: rect.width, height: rect.height };
+}
+
+class InitialSplitState {
+    public initialMousePos: [number, number];
+    public initialPortions: number[];
+    public separatorIndex: number;
+    public separatorSize: Size;
+    public wrapperSize: Size;
+
+    constructor() {
+        this.initialMousePos = [0, 0];
+        this.initialPortions = [];
+        this.separatorIndex = 0;
+        this.separatorSize = { width: 0, height: 0 };
+        this.wrapperSize = { width: 0, height: 0 };
+    }
+
+    public updateMousePos(ev: React.MouseEvent): void {
+        this.initialMousePos = [ev.clientX, ev.clientY];
+    }
+
+    public updateSeparatorAndWrapperSizes(ev: React.MouseEvent): void {
+        const [separatorElement, wrapperElement] =
+            this.getSeparatorAndWrapper(ev);
+        this.separatorSize = getElementSize(separatorElement);
+        this.wrapperSize = getElementSize(wrapperElement);
+    }
+
+    private getSeparatorAndWrapper(
+        ev: React.MouseEvent
+    ): [HTMLElement, HTMLElement] {
+        const separatorElement = ev.currentTarget as HTMLElement;
+        const wrapperElement = separatorElement.parentElement!;
+        return [separatorElement, wrapperElement];
+    }
+
+    public updateInitialPortions(portions: number[]) {
+        this.initialPortions = [...portions];
+    }
+}
+
+export function useSplitLayoutHandler(
+    numberOfComponents: number, //FIXME: TIENE QUE SER DOS O MAS (mirar getNewPortions)
+    minSizes: number[],
+    direction: Direction
+): [number[], (index: number, ev: React.MouseEvent) => void] {
+    const [normalizedPortions, setNormalizedPortions] = useState(
+        new Array(numberOfComponents).fill(1 / numberOfComponents)
+    );
+
+    const initialSplitStateRef = useRef(new InitialSplitState());
+    const splitLayoutEventHandler = useRef(new SplitLayoutEventHandler());
+
+    useEffect(() => {
+        splitLayoutEventHandler.current.onSeparatorMove = (
+            clientX,
+            clientY
+        ) => {
+            setNormalizedPortions((prevPortions) => {
+                const normalizedDisplacement = getNormalizedDisplacement(
+                    clientX,
+                    clientY
+                );
+
+                const newPortions = getNewPortions(
+                    prevPortions,
+                    normalizedDisplacement
+                );
+                return [...newPortions];
+            });
+        };
+    }, []);
+
+    useEffect(() => {
+        splitLayoutEventHandler.current.onSeparatorMouseDown = (
+            separatorIndex,
+            ev
+        ) => {
+            const initialSplitState = initialSplitStateRef.current;
+            initialSplitState.updateMousePos(ev);
+            initialSplitState.separatorIndex = separatorIndex;
+            initialSplitState.updateSeparatorAndWrapperSizes(ev);
+            initialSplitState.updateInitialPortions(normalizedPortions);
+        };
+    }, [normalizedPortions]);
+
+    function getMouseDisplacement(clientX: number, clientY: number): number {
+        if (direction == Direction.HORIZONTAL) {
+            return clientX - initialSplitStateRef.current.initialMousePos[0];
+        } else {
+            return clientY - initialSplitStateRef.current.initialMousePos[1];
+        }
+    }
+
+    function getNormalizedDisplacement(
+        clientX: number,
+        clientY: number
+    ): number {
+        let initialSplitState = initialSplitStateRef.current;
+        const screenDisplacement = getMouseDisplacement(clientX, clientY);
+        const wrapperLength = getLength(initialSplitState.wrapperSize);
+        const wrapperLengthWithoutSeparators =
+            wrapperLength -
+            getLength(initialSplitState.separatorSize) *
+                (numberOfComponents - 1);
+        return screenDisplacement / wrapperLengthWithoutSeparators;
+    }
+
+    function getLength(size: Size): number {
+        if (direction == Direction.HORIZONTAL) {
+            return size.width;
+        } else {
+            return size.height;
+        }
+    }
+
+    function getNewPortions(
+        prevPortions: number[],
+        normalizedDisplacement: number
+    ) {
+        const newPortions = getPortionsWithDisplacement(
+            normalizedDisplacement,
+            prevPortions
+        );
+        if (
+            newPortions.reduce(
+                (prevPortion, currentPortion) => prevPortion + currentPortion,
+                0
+            ) <= 1
+        ) {
+            return newPortions;
+        } else {
+            return [...prevPortions];
+        }
+    }
+
+    function getPortionsWithDisplacement(
+        normalizedDisplacement: number,
+        prevPortions: number[]
+    ) {
+        const initialPortions = initialSplitStateRef.current.initialPortions;
+        const separatorIndex = initialSplitStateRef.current.separatorIndex;
+        let remaindingDisplacement = Math.abs(normalizedDisplacement);
+
+        const newPortions = [...prevPortions];
+        if (normalizedDisplacement > 0) {
+            newPortions[separatorIndex] =
+                initialPortions[separatorIndex] +
+                Math.abs(normalizedDisplacement);
+            distributeDisplacementForward(
+                initialPortions,
+                remaindingDisplacement,
+                newPortions,
+                separatorIndex
+            );
+        } else {
+            newPortions[separatorIndex + 1] =
+                initialPortions[separatorIndex + 1] +
+                Math.abs(normalizedDisplacement);
+            distributeDisplacementBackwards(
+                initialPortions,
+                remaindingDisplacement,
+                newPortions,
+                separatorIndex
+            );
+        }
+
+        return newPortions;
+    }
+
+    function distributeDisplacementForward(
+        initialPortions: number[],
+        remaindingDisplacement: number,
+        newPortions: number[],
+        separatorIndex: number
+    ) {
+        iterateFrom(
+            initialPortions,
+            (portion, index) => {
+                if (remaindingDisplacement != 0) {
+                    [newPortions[index], remaindingDisplacement] = clampPortion(
+                        portion,
+                        minSizes[index],
+                        remaindingDisplacement
+                    );
+                }
+            },
+            separatorIndex + 1
+        );
+    }
+
+    function distributeDisplacementBackwards(
+        initialPortions: number[],
+        remaindingDisplacement: number,
+        newPortions: number[],
+        separatorIndex: number
+    ) {
+        iterateFromReverse(
+            initialPortions,
+            (portion, index) => {
+                if (remaindingDisplacement != 0) {
+                    [newPortions[index], remaindingDisplacement] = clampPortion(
+                        portion,
+                        minSizes[index],
+                        remaindingDisplacement
+                    );
+                }
+            },
+            separatorIndex
+        );
+    }
+
+    function clampPortion(
+        portion: number,
+        minPortion: number,
+        displacement: number
+    ): [number, number] {
+        const newPortion = Math.max(portion - displacement, minPortion);
+        const remaindingDisplacement = Math.max(
+            displacement - (portion - newPortion),
+            0
+        );
+        return [newPortion, remaindingDisplacement];
+    }
+
+    return [
+        normalizedPortions,
+        splitLayoutEventHandler.current.handleSeperatorMouseDown,
+    ];
+}


### PR DESCRIPTION
This PR introduces a major refactor to the `SplitLayout`. It's now separated into three main parts:
- The view: `SplitLayout.tsx`
- The state: `useSplitLayoutHandler.ts`
- The DOM Events: `SplitLayoutEventHandler.ts`

The view and the event handler are quite simple. The most complex part is the `useSplitLayoutHandler` which holds the logic for calculating the size of the components as the user moves the mouse.

Two major improvements that this PR adds are:
- Minimum sizes for each component
- If a component reaches min size, the next one begins shrinking

[screen-capture (12).webm](https://user-images.githubusercontent.com/114338434/208507096-cb1b7285-a919-41fb-88b6-a7c892fdf9f3.webm)
