### PR TITLE
[PR1] DEV-97 Refactored Chart

### DIFF
--- a/src/components/Caret/Caret.module.scss
+++ b/src/components/Caret/Caret.module.scss
@@ -1,8 +1,8 @@
 .wrapper {
-  width: min-content;
-  height: min-content;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  cursor: pointer;
+    width: min-content;
+    height: min-content;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
 }

--- a/src/components/ChartMenu/Chart/Chart.module.scss
+++ b/src/components/ChartMenu/Chart/Chart.module.scss
@@ -7,11 +7,14 @@
     display: grid;
     grid-template-rows: 15rem auto;
 
-    border: 2px solid #d3d8df;
+    border: 1px solid black;
     border-radius: styles.$normal-border-radius;
     overflow: hidden;
-
     position: relative;
+
+    &:hover .removeBtn {
+        opacity: 1;
+    }
 }
 
 .removeBtn {
@@ -23,12 +26,9 @@
     height: min-content;
 
     font-size: 1.5rem;
-    color: red;
+    color: black;
     line-height: 60%;
     cursor: pointer;
-}
-
-.chartWrapper {
-    width: 100%;
-    height: 100%;
+    opacity: 0;
+    transition: styles.$opacity-transition;
 }

--- a/src/components/ChartMenu/Chart/Chart.tsx
+++ b/src/components/ChartMenu/Chart/Chart.tsx
@@ -2,49 +2,50 @@ import styles from "@components/ChartMenu/Chart/Chart.module.scss";
 import Legend from "@components/ChartMenu/Chart/Legend/Legend";
 import { ChartElement } from "@components/ChartMenu/ChartElement";
 import { DragEvent, useCallback } from "react";
-import LinesCanvas from "@components/ChartMenu/Chart/LinesCanvas/LinesCanvas";
-import { IoMdCloseCircle } from "react-icons/io";
+import { SVGLineChart } from "@components/ChartMenu/Chart/SVGLineChart/SVGLineChart";
+import { MdClose } from "react-icons/md";
+
 type Props = {
-  chartElement: ChartElement;
-  handleDropOnChart: (chartId: number, measurementName: string) => void;
-  removeElement: () => void;
-  removeLineItem: (id: string) => void;
+    chartElement: ChartElement;
+    handleDropOnChart: (chartId: number, measurementName: string) => void;
+    removeElement: () => void;
+    removeLineItem: (id: string) => void;
 };
 
 export const Chart = ({
-  chartElement,
-  handleDropOnChart,
-  removeElement,
-  removeLineItem,
+    chartElement,
+    handleDropOnChart,
+    removeElement,
+    removeLineItem,
 }: Props) => {
-  const handleDrop = useCallback(
-    (ev: DragEvent<HTMLDivElement>) => {
-      ev.stopPropagation();
-      handleDropOnChart(chartElement.id, ev.dataTransfer.getData("text/plain"));
-    },
-    [handleDropOnChart]
-  );
-  return (
-    <div
-      className={styles.wrapper}
-      onDragEnter={(ev) => {
-        ev.preventDefault();
-      }}
-      onDragOver={(ev) => {
-        ev.preventDefault();
-      }}
-      onDrop={handleDrop}
-    >
-      <div className={styles.removeBtn} onClick={removeElement}>
-        <IoMdCloseCircle />
-      </div>
-      <div className={styles.chartWrapper}>
-        <LinesCanvas key={chartElement.id} lineFigures={chartElement.lines} />
-      </div>
-      <Legend
-        legendItems={chartElement.lines}
-        removeItem={removeLineItem}
-      ></Legend>
-    </div>
-  );
+    const handleDrop = useCallback(
+        (ev: DragEvent<HTMLDivElement>) => {
+            ev.stopPropagation();
+            handleDropOnChart(
+                chartElement.id,
+                ev.dataTransfer.getData("text/plain")
+            );
+        },
+        [handleDropOnChart]
+    );
+    return (
+        <div
+            className={styles.wrapper}
+            onDragEnter={(ev) => {
+                ev.preventDefault();
+            }}
+            onDragOver={(ev) => {
+                ev.preventDefault();
+            }}
+            //FIXME: no funciona si lo haces sobre el gráfico (sobre la parte pintada)
+            onDrop={handleDrop}
+        >
+            <MdClose className={styles.removeBtn} onClick={removeElement} />
+            <SVGLineChart lineFigures={chartElement.lines}></SVGLineChart>
+            <Legend
+                legendItems={chartElement.lines}
+                removeItem={removeLineItem}
+            ></Legend>
+        </div>
+    );
 };

--- a/src/components/ChartMenu/Chart/Legend/Legend.module.scss
+++ b/src/components/ChartMenu/Chart/Legend/Legend.module.scss
@@ -1,7 +1,7 @@
 #wrapper {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
 
-  background-color: #d3d8df;
+    border-top: 1px solid black;
 }

--- a/src/components/ChartMenu/Chart/Legend/LegendItem/LegendItem.module.scss
+++ b/src/components/ChartMenu/Chart/Legend/LegendItem/LegendItem.module.scss
@@ -3,15 +3,13 @@
 .wrapper {
     width: 100%;
     display: grid;
-    grid-template-columns: auto auto 1fr;
+    grid-template-columns: auto 1fr auto;
     align-items: center;
-    padding: 0.5rem;
-    @include styles.normal-text-style;
+    padding: 0.5rem 0;
+    @include styles.alternate-code-text;
 
-    &:not(:hover) {
-        .removeBtn {
-            visibility: hidden;
-        }
+    &:hover .removeBtn {
+        opacity: 1;
     }
 }
 
@@ -19,18 +17,19 @@
     justify-self: right;
     display: flex;
     align-items: center;
+    margin: 0 0.6rem;
     cursor: pointer;
-
-    > * {
-        transform: scale(1.5) translate(0.4px, 0.4px);
-    }
+    color: black;
+    transform: scale(1.3);
+    transition: styles.$opacity-transition;
+    opacity: 0;
 }
 
 .lineColor {
-    width: 1.8rem;
+    width: 1.5rem;
     height: 0.5rem;
     border-radius: 5rem;
+    margin: 0 0.6rem;
     //FIXME: diseño alineado con y sin lineColor, mismo espacio entre borde y line que entre line y name
-    margin-right: 0.8rem;
     background-color: blue;
 }

--- a/src/components/ChartMenu/Chart/Legend/LegendItem/LegendItem.tsx
+++ b/src/components/ChartMenu/Chart/Legend/LegendItem/LegendItem.tsx
@@ -1,28 +1,27 @@
 import styles from "@components/ChartMenu/Chart/Legend/LegendItem/LegendItem.module.scss";
-import { HSLColor, hslToHex } from "@utils/color";
+import { HSLAColor, hslaToHex, hslaToString } from "@utils/color";
 import { MdClose } from "react-icons/md";
 type Props = {
-  data: LegendItemData;
-  removeItem: () => void;
+    data: LegendItemData;
+    removeItem: () => void;
 };
 
 export type LegendItemData = {
-  name: string;
-  color: HSLColor;
+    name: string;
+    color: HSLAColor;
 };
 
 export const LegendItem = ({ data, removeItem }: Props) => {
-  let hexColor = hslToHex(data.color);
-  return (
-    <div className={styles.wrapper}>
-      <div
-        className={styles.lineColor}
-        style={{ backgroundColor: `#${hexColor.r}${hexColor.g}${hexColor.b}` }}
-      ></div>
-      <div className={styles.name}>{data.name}</div>
-      <div className={styles.removeBtn} onClick={removeItem}>
-        <MdClose />
-      </div>
-    </div>
-  );
+    return (
+        <div className={styles.wrapper}>
+            <div
+                className={styles.lineColor}
+                style={{
+                    backgroundColor: hslaToString(data.color),
+                }}
+            ></div>
+            <div className={styles.name}>{data.name}</div>
+            <MdClose className={styles.removeBtn} onClick={removeItem} />
+        </div>
+    );
 };

--- a/src/components/ChartMenu/Chart/SVGLineChart/Axis/Axis.tsx
+++ b/src/components/ChartMenu/Chart/SVGLineChart/Axis/Axis.tsx
@@ -1,0 +1,58 @@
+import { Mark } from "@components/ChartMenu/Chart/SVGLineChart/Axis/Mark/Mark";
+import { useId } from "@hooks/useId";
+
+type Props = {
+    minY: number;
+    maxY: number;
+    color: string;
+    strokeWidth: string;
+};
+export const Axis = ({ minY, maxY, color, strokeWidth }: Props) => {
+    const viewBoxWidth = 800;
+    const viewBoxHeight = 550;
+    const symbolId = useId();
+    const numberOfMarks = 6;
+
+    let verticalValues = [];
+    for (let i = 0; i < numberOfMarks; i++) {
+        verticalValues[i] = minY + ((maxY - minY) * i) / numberOfMarks;
+    }
+
+    return (
+        <>
+            <symbol
+                id={symbolId}
+                stroke={color}
+                width="20rem"
+                height="100%"
+                strokeWidth={strokeWidth}
+                vectorEffect={"non-scaling-stroke"}
+                preserveAspectRatio="none"
+                strokeLinecap="square"
+                viewBox={`0 0 ${viewBoxWidth} ${viewBoxHeight}`}
+                style={{ overflow: "visible" }}
+            >
+                {verticalValues.map((value, index) => {
+                    const offset =
+                        (viewBoxHeight / (numberOfMarks - 1)) * index;
+                    return (
+                        <Mark
+                            key={index}
+                            xPos={0}
+                            yPos={viewBoxHeight - offset}
+                            value={value}
+                        ></Mark>
+                    );
+                })}
+                <line
+                    x1={0}
+                    y1={0}
+                    x2={0}
+                    y2={viewBoxHeight}
+                    vectorEffect={"non-scaling-stroke"}
+                ></line>
+            </symbol>
+            <use href={`#${symbolId}`} x="0" y="0" />
+        </>
+    );
+};

--- a/src/components/ChartMenu/Chart/SVGLineChart/Axis/Mark/Mark.module.scss
+++ b/src/components/ChartMenu/Chart/SVGLineChart/Axis/Mark/Mark.module.scss
@@ -1,0 +1,6 @@
+.text {
+    font-family: Consolas, monospace;
+    font-size: 1.8rem;
+    stroke: none;
+    fill: black;
+}

--- a/src/components/ChartMenu/Chart/SVGLineChart/Axis/Mark/Mark.tsx
+++ b/src/components/ChartMenu/Chart/SVGLineChart/Axis/Mark/Mark.tsx
@@ -1,0 +1,31 @@
+import styles from "@components/ChartMenu/Chart/SVGLineChart/Axis/Mark/Mark.module.scss";
+
+type Props = {
+    xPos: number;
+    yPos: number;
+    value: number;
+};
+
+export const Mark = ({ xPos, yPos, value }: Props) => {
+    const markLength = 10;
+    return (
+        <g>
+            <line
+                x1={xPos}
+                y1={yPos}
+                x2={xPos + markLength}
+                y2={yPos}
+                vectorEffect={"non-scaling-stroke"}
+            ></line>
+
+            <text
+                x={xPos - 18}
+                y={yPos + 9}
+                className={styles.text}
+                textAnchor={"end"}
+            >
+                {value.toFixed(1)}
+            </text>
+        </g>
+    );
+};

--- a/src/components/ChartMenu/Chart/SVGLineChart/LineFigure/LineFigure.tsx
+++ b/src/components/ChartMenu/Chart/SVGLineChart/LineFigure/LineFigure.tsx
@@ -1,0 +1,79 @@
+import { LineFigure as LineFigureElement } from "@components/ChartMenu/ChartElement";
+import { getVectorLimits } from "@utils/math";
+import { getSofterHSLAColor, hslaToHex, hslaToString } from "@utils/color";
+
+function normalize(
+    number: number,
+    min: number,
+    max: number,
+    totalWidth: number
+): number {
+    if (max != min) {
+        return ((number - min) / (max - min)) * totalWidth;
+    } else {
+        return totalWidth / 2;
+    }
+}
+
+function getSVGPath(
+    line: number[],
+    viewBoxWidth: number,
+    min: number,
+    max: number
+): string {
+    if (line.length >= 2 && max != -Infinity && min != Infinity) {
+        const startingPoint = `M 0 ${
+            viewBoxWidth - normalize(line[0], min, max, viewBoxWidth)
+        }`;
+        let linePath = "";
+        for (let index = 1; index < line.length; index++) {
+            linePath += `L ${normalize(index, 0, line.length, viewBoxWidth)} ${
+                viewBoxWidth - normalize(line[index], min, max, viewBoxWidth)
+            }`;
+
+            linePath += " ";
+        }
+        return startingPoint + " " + linePath;
+    } else {
+        return "M 0 0";
+    }
+}
+
+type Props = {
+    lineFigure: LineFigureElement;
+    min: number;
+    max: number;
+    viewBoxWidth: number;
+    viewBoxHeight: number;
+};
+
+export const LineFigure = ({
+    lineFigure,
+    min,
+    max,
+    viewBoxWidth,
+    viewBoxHeight,
+}: Props) => {
+    const colorString = hslaToString(lineFigure.color);
+    const svgPath = getSVGPath(lineFigure.vector, viewBoxWidth, min, max);
+    return (
+        <>
+            <path
+                vectorEffect={"non-scaling-stroke"}
+                d={svgPath}
+                stroke={colorString}
+            ></path>
+            <path
+                vectorEffect={"non-scaling-stroke"}
+                d={
+                    svgPath +
+                    `L ${viewBoxWidth} ${viewBoxHeight} L 0 ${viewBoxHeight}`
+                }
+                stroke={"none"}
+                fill={hslaToString(
+                    getSofterHSLAColor({ ...lineFigure.color, a: 0.3 }, 18)
+                )}
+            ></path>
+        </>
+    );
+};

--- a/src/components/ChartMenu/Chart/SVGLineChart/Lines/Lines.module.scss
+++ b/src/components/ChartMenu/Chart/SVGLineChart/Lines/Lines.module.scss
@@ -1,0 +1,4 @@
+.path {
+    stroke-width: 2px;
+    filter: drop-shadow(0px -2px 1px rgba(255, 221, 194, 0.743));
+}

--- a/src/components/ChartMenu/Chart/SVGLineChart/Lines/Lines.tsx
+++ b/src/components/ChartMenu/Chart/SVGLineChart/Lines/Lines.tsx
@@ -1,0 +1,45 @@
+import { LineFigure } from "@components/ChartMenu/Chart/SVGLineChart/LineFigure/LineFigure";
+import { LineFigure as LineFigureElement } from "@components/ChartMenu/ChartElement";
+import { useId } from "@hooks/useId";
+type Props = {
+    lineFigures: Map<string, LineFigureElement>;
+    maxOfLines: number;
+    minOfLines: number;
+    viewBoxWidth: number;
+    viewBoxHeight: number;
+};
+export const Lines = ({
+    lineFigures,
+    maxOfLines,
+    minOfLines,
+    viewBoxWidth,
+    viewBoxHeight,
+}: Props) => {
+    const symbolId = useId();
+
+    return (
+        <>
+            <symbol
+                id={symbolId}
+                width="100%"
+                height="100%"
+                viewBox={`0 0 ${viewBoxWidth} ${viewBoxHeight}`}
+                preserveAspectRatio="none"
+            >
+                {Array.from(lineFigures.entries()).map(([key, lineFigure]) => {
+                    return (
+                        <LineFigure
+                            key={key}
+                            lineFigure={lineFigure}
+                            max={maxOfLines}
+                            min={minOfLines}
+                            viewBoxWidth={viewBoxWidth}
+                            viewBoxHeight={viewBoxHeight}
+                        ></LineFigure>
+                    );
+                })}
+            </symbol>
+            <use href={`#${symbolId}`} x="0" y="0" />
+        </>
+    );
+};

--- a/src/components/ChartMenu/Chart/SVGLineChart/SVGLineChart.module.scss
+++ b/src/components/ChartMenu/Chart/SVGLineChart/SVGLineChart.module.scss
@@ -1,0 +1,10 @@
+.wrapper {
+    width: 100%;
+    height: 100%;
+    padding: 1rem;
+    padding-left: 3.5rem;
+}
+
+svg {
+    overflow: visible;
+}

--- a/src/components/ChartMenu/Chart/SVGLineChart/SVGLineChart.tsx
+++ b/src/components/ChartMenu/Chart/SVGLineChart/SVGLineChart.tsx
@@ -1,0 +1,45 @@
+import styles from "@components/ChartMenu/Chart/SVGLineChart/SVGLineChart.module.scss";
+import { LineFigure as LineFigureElement } from "@components/ChartMenu/ChartElement";
+import { Lines } from "@components/ChartMenu/Chart/SVGLineChart/Lines/Lines";
+import { Axis } from "@components/ChartMenu/Chart/SVGLineChart/Axis/Axis";
+import { getMultipleVectorsLimits } from "@utils/math";
+import { useEffect, useRef } from "react";
+type Props = {
+    lineFigures: Map<string, LineFigureElement>;
+};
+
+export const SVGLineChart = ({ lineFigures }: Props) => {
+    const viewBoxWidth = 500;
+    const viewBoxHeight = 500;
+    const minOfLines = useRef(Infinity);
+    const maxOfLines = useRef(-Infinity);
+
+    useEffect(() => {
+        const vectors = Array.from(lineFigures.values()).map(
+            (figure) => figure.vector
+        );
+        [minOfLines.current, maxOfLines.current] =
+            getMultipleVectorsLimits(vectors);
+    }, [lineFigures]);
+
+    return (
+        <div className={styles.wrapper}>
+            <svg width="100%" height="100%" className={styles.svg} fill="none">
+                <Lines
+                    lineFigures={lineFigures}
+                    minOfLines={minOfLines.current}
+                    maxOfLines={maxOfLines.current}
+                    viewBoxHeight={viewBoxHeight}
+                    viewBoxWidth={viewBoxWidth}
+                ></Lines>
+
+                <Axis
+                    strokeWidth="1px"
+                    color="black"
+                    minY={minOfLines.current}
+                    maxY={maxOfLines.current}
+                ></Axis>
+            </svg>
+        </div>
+    );
+};

--- a/src/components/ChartMenu/ChartElement.ts
+++ b/src/components/ChartMenu/ChartElement.ts
@@ -1,22 +1,22 @@
 import { HSLColor } from "@utils/color";
 export type ChartElement = {
-  id: number;
-  lines: Map<string, LineFigure>; //TODO: consider changin to arr
+    id: number;
+    lines: Map<string, LineFigure>; //TODO: consider changin to arr
 };
 
 export class LineFigure {
-  public name: string;
-  public vector: number[];
-  public color: HSLColor;
+    public name: string;
+    public vector: number[];
+    public color: HSLColor;
 
-  constructor(name: string, color: HSLColor) {
-    this.name = name;
-    this.vector = new Array(200).fill(0);
-    this.color = color;
-  }
+    constructor(name: string, color: HSLColor) {
+        this.name = name;
+        this.vector = new Array(1000).fill(0);
+        this.color = color;
+    }
 
-  public updateVector(newValue: number) {
-    this.vector.push(newValue);
-    this.vector.shift();
-  }
+    public updateVector(newValue: number) {
+        this.vector.push(newValue);
+        this.vector.shift();
+    }
 }

--- a/src/components/ChartMenu/ChartList/ChartList.module.scss
+++ b/src/components/ChartMenu/ChartList/ChartList.module.scss
@@ -1,0 +1,14 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    width: 100%;
+    height: 100%;
+    background-color: #fcfcfc;
+    padding: 1rem;
+    overflow: auto;
+
+    border: 1px solid black;
+    border-left: 0;
+}

--- a/src/components/ChartMenu/ChartList/ChartList.tsx
+++ b/src/components/ChartMenu/ChartList/ChartList.tsx
@@ -1,0 +1,73 @@
+import { ChartElement } from "@components/ChartMenu/ChartElement";
+import { Chart } from "@components/ChartMenu/Chart/Chart";
+import { useChartElements } from "@components/ChartMenu/useChartElements";
+import { store } from "../../../store";
+import { getMeasurement } from "@models/PodData/PodData";
+import { DragEvent } from "react";
+import { useInterval } from "@hooks/useInterval";
+
+import styles from "@components/ChartMenu/ChartList/ChartList.module.scss";
+
+export const ChartList = () => {
+    const [
+        chartElements,
+        addElement,
+        addLineToElement,
+        updateElements,
+        removeElement,
+        removeLineItem,
+    ] = useChartElements();
+
+    function getUpdatedMeasurements(): Map<string, number> {
+        let state = store.getState();
+        let measurements = new Map<string, number>();
+        for (let element of chartElements) {
+            for (let [name, _] of element.lines) {
+                measurements.set(
+                    name,
+                    getMeasurement(state.podData.boards, name).value as number
+                );
+            }
+        }
+        return measurements;
+    }
+
+    useInterval(() => {
+        updateElements(getUpdatedMeasurements());
+    }, 1000 / 60);
+
+    function handleDrop(ev: DragEvent<HTMLDivElement>) {
+        addElement(ev.dataTransfer.getData("text/plain"));
+    }
+
+    function handleDropOnChart(id: number, measurementName: string) {
+        addLineToElement(id, measurementName);
+    }
+
+    return (
+        <div
+            className={styles.wrapper}
+            onDrop={handleDrop}
+            onDragEnter={(ev) => {
+                ev.preventDefault();
+            }}
+            onDragOver={(ev) => {
+                ev.preventDefault();
+            }}
+        >
+            {chartElements.map((chartElement) => {
+                return (
+                    <Chart
+                        key={chartElement.id}
+                        chartElement={chartElement}
+                        handleDropOnChart={handleDropOnChart}
+                        removeElement={() => removeElement(chartElement.id)}
+                        removeLineItem={(lineId: string) => {
+                            removeLineItem(chartElement.id, lineId);
+                        }}
+                    />
+                );
+            })}
+        </div>
+    );
+};

--- a/src/components/ChartMenu/ChartMenu.module.scss
+++ b/src/components/ChartMenu/ChartMenu.module.scss
@@ -3,23 +3,8 @@
     width: 100%;
     height: 100%;
     display: grid;
-    grid-template-columns: 12rem 1fr;
+    grid-template-columns: auto 1fr;
 
     border-radius: styles.$normal-border-radius;
     overflow: hidden;
-}
-
-.chartList {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-
-    width: 100%;
-    height: 100%;
-    background-color: #fcfcfc;
-    padding: 1rem;
-    overflow: auto;
-
-    border: 1px solid black;
-    border-left: 0;
 }

--- a/src/components/ChartMenu/ChartMenu.tsx
+++ b/src/components/ChartMenu/ChartMenu.tsx
@@ -1,80 +1,17 @@
 import { useSelector } from "react-redux";
-import { useInterval } from "@hooks/useInterval";
 import Sidebar from "@components/ChartMenu/Sidebar/Sidebar";
 import styles from "@components/ChartMenu/ChartMenu.module.scss";
-import { DragEvent, useEffect } from "react";
-import { Chart } from "@components/ChartMenu/Chart/Chart";
-import { selectPodDataNames } from "@slices/podDataSlice";
+import { selectNumericPodDataNames } from "@slices/podDataSlice";
 import lodash from "lodash";
-import { useChartElements } from "./useChartElements";
-import { store } from "../../store";
-import { getMeasurement } from "@models/PodData/PodData";
+import { ChartList } from "@components/ChartMenu/ChartList/ChartList";
+import { TreeNode } from "@components/ChartMenu/TreeNode";
+
 export const ChartMenu = () => {
-    let boardNodes = useSelector(selectPodDataNames, lodash.isEqual);
-
-    const [
-        chartElements,
-        addElement,
-        addLineToElement,
-        updateElements,
-        removeElement,
-        removeLineItem,
-    ] = useChartElements();
-
-    function getUpdatedMeasurements(): Map<string, string> {
-        let state = store.getState();
-        let measurements = new Map<string, string>();
-        for (let element of chartElements) {
-            for (let [name, _] of element.lines) {
-                measurements.set(
-                    name,
-                    //TODO: HACER QUE SOLO APAREZCAN EN EL SIDEBAR LOS QUE SON NUMEROS ASI NO HAY QUE CONVERTIR LUEGO
-                    getMeasurement(state.podData.boards, name).value as string
-                );
-            }
-        }
-        return measurements;
-    }
-
-    useInterval(() => {
-        updateElements(getUpdatedMeasurements());
-    }, 1000 / 60);
-
-    function handleDrop(ev: DragEvent<HTMLDivElement>) {
-        addElement(ev.dataTransfer.getData("text/plain"));
-    }
-
-    function handleDropOnChart(id: number, measurementName: string) {
-        addLineToElement(id, measurementName);
-    }
-
+    const boardNodes = useSelector(selectNumericPodDataNames, lodash.isEqual);
     return (
-        <div id={styles.wrapper}>
+        <div className={styles.wrapper}>
             <Sidebar boardNodes={boardNodes} />
-            <div
-                id={styles.chartList}
-                onDrop={handleDrop}
-                onDragEnter={(ev) => {
-                    ev.preventDefault();
-                }}
-                onDragOver={(ev) => {
-                    ev.preventDefault();
-                }}
-            >
-                {chartElements.map((chartElement) => {
-                    return (
-                        <Chart
-                            key={chartElement.id}
-                            chartElement={chartElement}
-                            handleDropOnChart={handleDropOnChart}
-                            removeElement={() => removeElement(chartElement.id)}
-                            removeLineItem={(lineId: string) => {
-                                removeLineItem(chartElement.id, lineId);
-                            }}
-                        />
-                    );
-                })}
-            </div>
+            <ChartList></ChartList>
         </div>
     );
 };

--- a/src/components/ChartMenu/Sidebar/BoardItem/BoardItem.module.scss
+++ b/src/components/ChartMenu/Sidebar/BoardItem/BoardItem.module.scss
@@ -1,20 +1,32 @@
 @use "@styles/styles";
-#header {
-    margin-bottom: 1rem;
-    padding: 0.5rem;
-    background-color: #e4e5e7;
 
-    @include styles.normal-text-style;
-    color: #505868;
-    font-weight: bold;
-}
-
-#packetList {
+.wrapper {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+
+    @include styles.code-text;
 }
 
-.treeNode {
-    margin-left: 0.8rem;
+.header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.5rem;
+    background-color: styles.lightness(styles.$base-color, 30%);
+
+    color: styles.$base-color;
+    font-weight: bold;
+
+    border-bottom: 1px solid styles.lightness(styles.$base-color, 18%);
+}
+
+.packetList {
+    display: flex;
+    flex-direction: column;
+    padding-right: 1.5rem;
+    overflow: hidden;
+    > * {
+        margin-bottom: 0.8rem;
+    }
 }

--- a/src/components/ChartMenu/Sidebar/BoardItem/BoardItem.tsx
+++ b/src/components/ChartMenu/Sidebar/BoardItem/BoardItem.tsx
@@ -2,6 +2,8 @@ import styles from "@components/ChartMenu/Sidebar/BoardItem/BoardItem.module.scs
 import { Board } from "@models/PodData/Board";
 import PacketItem from "@components/ChartMenu/Sidebar/PacketItem/PacketItem";
 import { TreeNode } from "@components/ChartMenu/TreeNode";
+import { Caret } from "@components/Caret/Caret";
+import { useState } from "react";
 
 type Props = {
     name: string;
@@ -9,17 +11,35 @@ type Props = {
 };
 
 export const BoardItem = ({ name, packetNodes }: Props) => {
+    const [isOpen, setIsOpen] = useState(false);
     return (
-        <div id={styles.wrapper}>
-            <div id={styles.header}>{name}</div>
-            <PacketItems packetNodes={packetNodes} />
+        <div className={styles.wrapper}>
+            <div className={styles.header}>
+                <Caret
+                    isOpen={isOpen}
+                    onClick={() => {
+                        setIsOpen((prev) => !prev);
+                    }}
+                />
+                {name}
+            </div>
+            <PacketItems packetNodes={packetNodes} isVisible={isOpen} />
         </div>
     );
 };
 
-const PacketItems = ({ packetNodes }: { packetNodes: TreeNode }) => {
+const PacketItems = ({
+    packetNodes,
+    isVisible,
+}: {
+    packetNodes: TreeNode;
+    isVisible: boolean;
+}) => {
     return (
-        <div id={`${styles.packetList} ${styles.treeNode}`}>
+        <div
+            className={`${styles.packetList} treeNode`}
+            style={{ height: isVisible ? "auto" : "0" }}
+        >
             {Object.entries(packetNodes).map(([name, measurementNodes]) => {
                 return (
                     <PacketItem

--- a/src/components/ChartMenu/Sidebar/MeasurementItem/MeasurementItem.module.scss
+++ b/src/components/ChartMenu/Sidebar/MeasurementItem/MeasurementItem.module.scss
@@ -1,16 +1,10 @@
 @use "@styles/styles";
 
-.treeNode {
-    margin-left: 0.8rem;
-}
-
 .wrapper {
     display: grid;
     align-items: center;
     grid-template-columns: auto 1fr;
     column-gap: 0.3rem;
-    @include styles.normal-text-style;
     font-weight: 500;
-    color: #505868;
     cursor: pointer;
 }

--- a/src/components/ChartMenu/Sidebar/MeasurementItem/MeasurementItem.tsx
+++ b/src/components/ChartMenu/Sidebar/MeasurementItem/MeasurementItem.tsx
@@ -3,24 +3,24 @@ import { Measurement } from "@models/PodData/Measurement";
 import { DragEvent, memo } from "react";
 import { FiBox } from "react-icons/fi";
 type Props = {
-  name: string;
+    name: string;
 };
 
 const MeasurementItem = ({ name }: Props) => {
-  function handleDragStart(ev: DragEvent<HTMLDivElement>) {
-    ev.dataTransfer.setData("text/plain", name);
-  }
+    function handleDragStart(ev: DragEvent<HTMLDivElement>) {
+        ev.dataTransfer.setData("text/plain", name);
+    }
 
-  return (
-    <div
-      key={name}
-      className={`${styles.wrapper} ${styles.treeNode}`}
-      draggable="true"
-      onDragStart={handleDragStart}
-    >
-      <FiBox /> {name}
-    </div>
-  );
+    return (
+        <div
+            key={name}
+            className={`${styles.wrapper} treeNode`}
+            draggable="true"
+            onDragStart={handleDragStart}
+        >
+            <FiBox /> {name}
+        </div>
+    );
 };
 
 export default MeasurementItem;

--- a/src/components/ChartMenu/Sidebar/PacketItem/PacketItem.module.scss
+++ b/src/components/ChartMenu/Sidebar/PacketItem/PacketItem.module.scss
@@ -1,22 +1,11 @@
 @use "@styles/styles";
-#wrapper {
+.wrapper {
     display: flex;
     flex-direction: column;
-    margin-bottom: 0.5rem;
 }
 
-#name {
+.name {
     margin-bottom: 0.5rem;
-
-    @include styles.normal-text-style;
     font-style: italic;
     color: #a9adb6;
-}
-
-#measurementList {
-    @include styles.normal-text-style;
-}
-
-.treeNode {
-    margin-left: 0.8rem;
 }

--- a/src/components/ChartMenu/Sidebar/PacketItem/PacketItem.tsx
+++ b/src/components/ChartMenu/Sidebar/PacketItem/PacketItem.tsx
@@ -9,8 +9,8 @@ type Props = {
 
 const PacketItem = ({ name, measurementNodes }: Props) => {
     return (
-        <div id={styles.wrapper} className={`${styles.treeNode}`}>
-            <div id={styles.name}>{name}</div>
+        <div className={`${styles.wrapper} treeNode`}>
+            <div className={styles.name}>{name}</div>
             <MeasurementItems measurementNodes={measurementNodes} />
         </div>
     );
@@ -22,7 +22,7 @@ const MeasurementItems = ({
     measurementNodes: TreeNode;
 }) => {
     return (
-        <div id={styles.measurementList}>
+        <div className={styles.measurementList}>
             {Object.keys(measurementNodes).map((name) => {
                 return <MeasurementItem key={name} name={name} />;
             })}

--- a/src/components/ChartMenu/Sidebar/Sidebar.module.scss
+++ b/src/components/ChartMenu/Sidebar/Sidebar.module.scss
@@ -1,11 +1,11 @@
 @use "@styles/styles";
-#wrapper {
-    width: 100%;
+.wrapper {
+    width: auto;
     height: 100%;
 
     display: flex;
     flex-direction: column;
-
-    background-color: #f2f2f2;
     overflow: auto;
+
+    background-color: styles.lightness(styles.$base-color, 35%);
 }

--- a/src/components/ChartMenu/Sidebar/Sidebar.tsx
+++ b/src/components/ChartMenu/Sidebar/Sidebar.tsx
@@ -1,4 +1,5 @@
 import styles from "@components/ChartMenu/Sidebar/Sidebar.module.scss";
+import "@components/ChartMenu/Sidebar/treeNode.scss";
 import { BoardItem } from "@components/ChartMenu/Sidebar/BoardItem/BoardItem";
 import { memo } from "react";
 import { TreeNode } from "@components/ChartMenu/TreeNode";
@@ -9,7 +10,7 @@ type Props = {
 
 const Sidebar = ({ boardNodes }: Props) => {
     return (
-        <div id={styles.wrapper}>
+        <div className={styles.wrapper}>
             {Object.entries(boardNodes).map(([name, packetNodes]) => {
                 return (
                     <BoardItem

--- a/src/components/ChartMenu/Sidebar/treeNode.scss
+++ b/src/components/ChartMenu/Sidebar/treeNode.scss
@@ -1,0 +1,3 @@
+.treeNode {
+    margin-left: 0.8rem;
+}

--- a/src/components/ChartMenu/useChartElements.ts
+++ b/src/components/ChartMenu/useChartElements.ts
@@ -1,116 +1,132 @@
 import { useState, useRef } from "react";
 import { ChartElement, LineFigure } from "@components/ChartMenu/ChartElement";
-import { HSLColor } from "@utils/color";
+import { HSLAColor } from "@utils/color";
 
-function getColor(offset: number): HSLColor {
-  return {
-    h: (32 + offset * 50) % 360,
-    s: 70,
-    l: 75,
-  };
+function getColor(offset: number): HSLAColor {
+    return {
+        h: (32 + offset * 50) % 360,
+        s: 90,
+        l: 75,
+        a: 1,
+    };
 }
 
 export function useChartElements(): [
-  ChartElement[],
-  (measurementName: string) => void,
-  (id: number, measurementName: string) => void,
-  (updatedMeasurements: Map<string, string>) => void,
-  (id: number) => void,
-  (chartId: number, lineItemId: string) => void
+    ChartElement[],
+    (measurementName: string) => void,
+    (id: number, measurementName: string) => void,
+    (updatedMeasurements: Map<string, number>) => void,
+    (id: number) => void,
+    (chartId: number, lineItemId: string) => void
 ] {
-  const [chartElements, setChartElements] = useState([] as ChartElement[]);
-  const chartIndex = useRef(0);
+    const [chartElements, setChartElements] = useState([] as ChartElement[]);
+    const chartIndex = useRef(0);
 
-  function addElement(measurementName: string): void {
-    const newElement = {
-      id: chartIndex.current,
-      lines: new Map([
-        [measurementName, new LineFigure(measurementName, getColor(0))],
-      ]),
-    };
+    function addElement(measurementName: string): void {
+        const newElement = {
+            id: chartIndex.current,
+            lines: new Map([
+                [measurementName, new LineFigure(measurementName, getColor(0))],
+            ]),
+        };
 
-    setChartElements((prevElements) => {
-      return [...prevElements, newElement];
-    });
-    chartIndex.current++;
-  }
-
-  function addLineToElement(id: number, measurementName: string): void {
-    if (isAlreadyInChart(id, measurementName)) {
-      return;
-    } else {
-      setChartElements((prevElements) => {
-        const index = prevElements.findIndex((element) => element.id == id);
-        const newElement = { ...prevElements[index] };
-
-        newElement.lines = new Map(
-          newElement.lines.set(
-            measurementName,
-            new LineFigure(measurementName, getColor(newElement.lines.size + 1))
-          )
-        );
-
-        return replaceElement(prevElements, newElement, index);
-      });
+        setChartElements((prevElements) => {
+            return [...prevElements, newElement];
+        });
+        chartIndex.current++;
     }
-  }
 
-  function isAlreadyInChart(id: number, measurementName: string): boolean {
-    let index = chartElements.findIndex((element) => element.id == id)!;
-    return chartElements[index].lines.has(measurementName);
-  }
+    function addLineToElement(id: number, measurementName: string): void {
+        if (isAlreadyInChart(id, measurementName)) {
+            return;
+        } else {
+            setChartElements((prevElements) => {
+                const index = prevElements.findIndex(
+                    (element) => element.id == id
+                );
+                const newElement = { ...prevElements[index] };
 
-  function replaceElement<T>(elementArr: T[], element: T, index: number): T[] {
-    return Object.assign([], elementArr, { index: element });
-  }
+                newElement.lines = new Map(
+                    newElement.lines.set(
+                        measurementName,
+                        new LineFigure(
+                            measurementName,
+                            getColor(newElement.lines.size + 1)
+                        )
+                    )
+                );
 
-  function updateElements(updatedMeasurements: Map<string, string>): void {
-    setChartElements((prevElements) => {
-      return prevElements.map((element) => {
-        for (let [name, value] of updatedMeasurements) {
-          if (element.lines.has(name)) {
-            let line = element.lines.get(name)!;
-            line.updateVector(Number.parseFloat(value));
-            element.lines.set(name, line);
-            let newLines = new Map(element.lines);
-            element.lines = newLines;
-          }
+                return replaceElement(prevElements, newElement, index);
+            });
         }
-        return element;
-      });
-    });
-  }
+    }
 
-  function removeElement(id: number): void {
-    setChartElements((prevElements) => {
-      return prevElements.filter((element) => {
-        return element.id != id;
-      });
-    });
-  }
+    function isAlreadyInChart(id: number, measurementName: string): boolean {
+        let index = chartElements.findIndex((element) => element.id == id)!;
+        return chartElements[index].lines.has(measurementName);
+    }
 
-  function removeLineItem(chartId: number, lineItemId: string) {
-    setChartElements((prevElements) => {
-      let elementIndex = prevElements.findIndex(
-        (element) => element.id == chartId
-      );
-      let newChartElement = prevElements[elementIndex];
+    function replaceElement<T>(
+        elementArr: T[],
+        element: T,
+        index: number
+    ): T[] {
+        return Object.assign([], elementArr, { index: element });
+    }
 
-      newChartElement.lines.delete(lineItemId);
-      if (newChartElement.lines.size == 0) {
-        return [...prevElements].filter((element) => element.id != chartId);
-      } else {
-        return replaceElement(prevElements, newChartElement, elementIndex);
-      }
-    });
-  }
+    function updateElements(updatedMeasurements: Map<string, number>): void {
+        setChartElements((prevElements) => {
+            return prevElements.map((element) => {
+                for (let [name, value] of updatedMeasurements) {
+                    if (element.lines.has(name)) {
+                        let line = element.lines.get(name)!;
+                        line.updateVector(value);
+                        element.lines.set(name, line);
+                        let newLines = new Map(element.lines);
+                        element.lines = newLines;
+                    }
+                }
+                return element;
+            });
+        });
+    }
 
-  return [
-    chartElements,
-    addElement,
-    addLineToElement,
-    updateElements,
-    removeElement,
-    removeLineItem,
-  ];
+    function removeElement(id: number): void {
+        setChartElements((prevElements) => {
+            return prevElements.filter((element) => {
+                return element.id != id;
+            });
+        });
+    }
+
+    function removeLineItem(chartId: number, lineItemId: string) {
+        setChartElements((prevElements) => {
+            let elementIndex = prevElements.findIndex(
+                (element) => element.id == chartId
+            );
+            let newChartElement = prevElements[elementIndex];
+
+            newChartElement.lines.delete(lineItemId);
+            if (newChartElement.lines.size == 0) {
+                return [...prevElements].filter(
+                    (element) => element.id != chartId
+                );
+            } else {
+                return replaceElement(
+                    prevElements,
+                    newChartElement,
+                    elementIndex
+                );
+            }
+        });
+    }
+
+    return [
+        chartElements,
+        addElement,
+        addLineToElement,
+        updateElements,
+        removeElement,
+        removeLineItem,
+    ];
 }

--- a/src/hooks/useId.ts
+++ b/src/hooks/useId.ts
@@ -1,0 +1,5 @@
+import { useRef } from "react";
+
+export function useId(): string {
+    return useRef(crypto.randomUUID()).current;
+}

--- a/src/styles/globalOverride.scss
+++ b/src/styles/globalOverride.scss
@@ -24,7 +24,7 @@ hr {
 //If it's only :root, font-size changes the base rem. If it's :root *, it affects everything, skipping inheritance.
 :root > * {
     box-sizing: border-box;
-    @include styles.normal-text-style;
+    @include styles.normal-text;
     scrollbar-track-color: transparent;
     scrollbar-color: rgb(68, 68, 68) none;
     user-select: none;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -8,7 +8,7 @@ $normal-text-color: #373c43;
 $alternate-text-color: #505868;
 $orange: #f28d30;
 $blue: #317ae7;
-$base-color: #64849c;
+$base-color: hsl(212, 27%, 55%);
 
 //DARK THEME
 $dark-isle-color: #404654;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,14 +1,14 @@
 @use "sass:color";
 
 // COLORS
-$background-color: #cee0f0;
+$background-color: #dce3eb;
 $isle-color: #ffffff;
 $title-color: #45677d;
 $normal-text-color: #373c43;
-$alternate-text-color: #5a6a89;
+$alternate-text-color: #505868;
 $orange: #f28d30;
 $blue: #317ae7;
-$sidebar-base-color: #f7dec8;
+$base-color: #64849c;
 
 //DARK THEME
 $dark-isle-color: #404654;
@@ -17,7 +17,8 @@ $dark-normal-text-color: #bec6d2;
 // FONTS
 //TODO: define fallbacks fonts in case some are not installed
 $sans-font: Inter, Helvetica, Arial;
-$code-font: Cascadia Code, Cascadia Mono, Consolas, Monoscape;
+$code-font: Consolas, Cascadia Code, Cascadia Mono, Monospace;
+$alternate-code-font: Consolas, Monospace;
 
 // FONT-SIZE
 $title-font-size: 1.9rem;
@@ -40,13 +41,21 @@ $normal-border-radius: 0.2rem;
 $normal-border-width: 1px;
 
 // TRANSITIONS
-$background-color-transition: background-color 0.08s linear;
+$normal-transition-time: 0.08s;
+$opacity-transition: opacity $normal-transition-time linear;
+$background-color-transition: background-color $normal-transition-time linear;
 
 // MIXINS
 @mixin code-text {
     font-family: $code-font;
     font-size: $normal-font-size;
     color: $normal-text-color;
+}
+
+@mixin alternate-code-text {
+    font-family: $alternate-code-font;
+    font-size: $normal-font-size;
+    color: $alternate-text-color;
 }
 
 @mixin title-text {
@@ -56,25 +65,32 @@ $background-color-transition: background-color 0.08s linear;
     font-weight: $bold-font-weight;
 }
 
-@mixin normal-text-style {
-    font-family: $code-font;
+@mixin normal-text {
+    font-family: $sans-font;
     font-size: $normal-font-size;
     color: $alternate-text-color;
     font-weight: $normal-font-weight;
 }
 
-@mixin subtitle-text-style {
+@mixin subtitle-text {
     font-family: $code-font;
     font-size: $normal-font-size;
     font-style: italic;
     color: #a9adb6;
 }
 
-@mixin tab-font {
+@mixin tab-text {
     font-family: $sans-font;
     font-size: $normal-font-size;
     font-weight: 500;
     color: $title-color;
+}
+
+@mixin inherit-text {
+    font-family: inherit;
+    font-size: inherit;
+    color: inherit;
+    font-weight: inherit;
 }
 
 @mixin undraggable {

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,37 +1,44 @@
-export type HSLColor = {
-  h: number;
-  s: number;
-  l: number;
+import { clamp } from "@utils/math";
+
+export type HSLAColor = {
+    h: number;
+    s: number;
+    l: number;
+    a: number;
 };
 
-export function hslToHex({ h, s, l }: HSLColor): {
-  r: string;
-  g: string;
-  b: string;
-} {
-  l /= 100;
-  const a = (s * Math.min(l, 1 - l)) / 100;
-  const f = (n: number) => {
-    const k = (n + h / 30) % 12;
-    const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-    return Math.round(255 * color)
-      .toString(16)
-      .padStart(2, "0"); // convert to Hex and prefix "0" if needed
-  };
-  return { r: f(0), g: f(8), b: f(4) };
+type RGBAColor = {
+    r: number;
+    g: number;
+    b: number;
+    a: number;
+};
+
+export function hslaToHex({ h, s, l, a }: HSLAColor): RGBAColor {
+    l /= 100;
+    const a2 = (s * Math.min(l, 1 - l)) / 100;
+    const f = (n: number) => {
+        const k = (n + h / 30) % 12;
+        const color = l - a2 * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+        return Math.round(255 * color)
+            .toString(16)
+            .padStart(2, "0"); // convert to Hex and prefix "0" if needed
+    };
+    return {
+        r: parseInt(f(0)),
+        g: parseInt(f(8)),
+        b: parseInt(f(4)),
+        a: a,
+    };
 }
 
-export function getSofterHSLColor(
-  { h, s, l }: HSLColor,
-  lightnessOffset: number
-): HSLColor {
-  return { h, s, l: l + clamp(lightnessOffset, 0, 100) } as HSLColor;
+export function getSofterHSLAColor(
+    { h, s, l, a }: HSLAColor,
+    lightnessOffset: number
+): HSLAColor {
+    return { h, s, l: l + clamp(lightnessOffset, 0, 100), a: a } as HSLAColor;
 }
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(min, value), max);
-}
-
-export function hslColorToString({ h, s, l }: HSLColor): string {
-  return "hsl(" + h + ", " + s + "%, " + l + "%)";
+export function hslaToString({ h, s, l, a }: HSLAColor): string {
+    return `hsl(${h},${s}%,${l}%,${a})`;
 }

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,11 +1,29 @@
 export function getVectorLimits(vector: number[]): [number, number] {
-  let max = -Infinity;
-  let min = Infinity;
+    let min = Infinity;
+    let max = -Infinity;
 
-  vector.forEach((value) => {
-    max = value > max ? value : max;
-    min = value < min ? value : min;
-  });
+    vector.forEach((value) => {
+        min = value < min ? value : min;
+        max = value > max ? value : max;
+    });
 
-  return [max, min];
+    return [min, max];
+}
+
+export function getMultipleVectorsLimits(vectors: number[][]) {
+    let [minOfLines, maxOfLines] = [Infinity, -Infinity];
+    for (let vector of vectors) {
+        const [localMin, localMax] = getVectorLimits(vector);
+        if (localMin < minOfLines) {
+            minOfLines = localMin;
+        }
+        if (localMax > maxOfLines) {
+            maxOfLines = localMax;
+        }
+    }
+    return [minOfLines, maxOfLines];
+}
+
+export function clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(min, value), max);
 }


### PR DESCRIPTION
This PR makes a complete refactor to the `Chart` component. I realized the canvas can't stretch to fill the parent container, so I rebuilt the Chart using SVG instead. Now it can stretch without any problem and is very performant. Beware that some files appear as changed because of the change in identation, those can be safely ignored.

For clarification:
- `Chart` is the component with both the graphs and the legend
- `Legend` is the list with all the measurements that are being drawn
- `LegendItem` is each element in the legend.
- `Axis` is the component that includes the vertical line with the numbered marks.
- `Mark` is each pair of number dash along the axis
- `LineFigure` is the component that draws one line
- `Lines` is the component that handles multiple LineFigures. The data they share is the minOfLines and maxOfLines. This represent the minimum and maximum values of among all lines. This is needed so the graph can scale the fit all lines completely at the same time (in the video it can be appreciated).
- `SVGLineChart` joins the lines with the axis in an SVG element

[screen-capture (13).webm](https://user-images.githubusercontent.com/114338434/209657697-53d4cd30-889b-4ba2-9c0e-4ee45bbb469c.webm)
