### PR TITLE
[PR2] DEV-97 Improved Sidebar and ChartMenu

### DIFF
--- a/src/components/Caret/Caret.module.scss
+++ b/src/components/Caret/Caret.module.scss
@@ -1,8 +1,8 @@
 .wrapper {
-  width: min-content;
-  height: min-content;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  cursor: pointer;
+    width: min-content;
+    height: min-content;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
 }

--- a/src/components/ChartMenu/ChartElement.ts
+++ b/src/components/ChartMenu/ChartElement.ts
@@ -1,22 +1,22 @@
 import { HSLColor } from "@utils/color";
 export type ChartElement = {
-  id: number;
-  lines: Map<string, LineFigure>; //TODO: consider changin to arr
+    id: number;
+    lines: Map<string, LineFigure>; //TODO: consider changin to arr
 };
 
 export class LineFigure {
-  public name: string;
-  public vector: number[];
-  public color: HSLColor;
+    public name: string;
+    public vector: number[];
+    public color: HSLColor;
 
-  constructor(name: string, color: HSLColor) {
-    this.name = name;
-    this.vector = new Array(200).fill(0);
-    this.color = color;
-  }
+    constructor(name: string, color: HSLColor) {
+        this.name = name;
+        this.vector = new Array(1000).fill(0);
+        this.color = color;
+    }
 
-  public updateVector(newValue: number) {
-    this.vector.push(newValue);
-    this.vector.shift();
-  }
+    public updateVector(newValue: number) {
+        this.vector.push(newValue);
+        this.vector.shift();
+    }
 }

--- a/src/components/ChartMenu/ChartList/ChartList.module.scss
+++ b/src/components/ChartMenu/ChartList/ChartList.module.scss
@@ -1,0 +1,14 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    width: 100%;
+    height: 100%;
+    background-color: #fcfcfc;
+    padding: 1rem;
+    overflow: auto;
+
+    border: 1px solid black;
+    border-left: 0;
+}

--- a/src/components/ChartMenu/ChartList/ChartList.tsx
+++ b/src/components/ChartMenu/ChartList/ChartList.tsx
@@ -1,0 +1,73 @@
+import { ChartElement } from "@components/ChartMenu/ChartElement";
+import { Chart } from "@components/ChartMenu/Chart/Chart";
+import { useChartElements } from "@components/ChartMenu/useChartElements";
+import { store } from "../../../store";
+import { getMeasurement } from "@models/PodData/PodData";
+import { DragEvent } from "react";
+import { useInterval } from "@hooks/useInterval";
+
+import styles from "@components/ChartMenu/ChartList/ChartList.module.scss";
+
+export const ChartList = () => {
+    const [
+        chartElements,
+        addElement,
+        addLineToElement,
+        updateElements,
+        removeElement,
+        removeLineItem,
+    ] = useChartElements();
+
+    function getUpdatedMeasurements(): Map<string, number> {
+        let state = store.getState();
+        let measurements = new Map<string, number>();
+        for (let element of chartElements) {
+            for (let [name, _] of element.lines) {
+                measurements.set(
+                    name,
+                    getMeasurement(state.podData.boards, name).value as number
+                );
+            }
+        }
+        return measurements;
+    }
+
+    useInterval(() => {
+        updateElements(getUpdatedMeasurements());
+    }, 1000 / 60);
+
+    function handleDrop(ev: DragEvent<HTMLDivElement>) {
+        addElement(ev.dataTransfer.getData("text/plain"));
+    }
+
+    function handleDropOnChart(id: number, measurementName: string) {
+        addLineToElement(id, measurementName);
+    }
+
+    return (
+        <div
+            className={styles.wrapper}
+            onDrop={handleDrop}
+            onDragEnter={(ev) => {
+                ev.preventDefault();
+            }}
+            onDragOver={(ev) => {
+                ev.preventDefault();
+            }}
+        >
+            {chartElements.map((chartElement) => {
+                return (
+                    <Chart
+                        key={chartElement.id}
+                        chartElement={chartElement}
+                        handleDropOnChart={handleDropOnChart}
+                        removeElement={() => removeElement(chartElement.id)}
+                        removeLineItem={(lineId: string) => {
+                            removeLineItem(chartElement.id, lineId);
+                        }}
+                    />
+                );
+            })}
+        </div>
+    );
+};

--- a/src/components/ChartMenu/ChartMenu.module.scss
+++ b/src/components/ChartMenu/ChartMenu.module.scss
@@ -3,23 +3,8 @@
     width: 100%;
     height: 100%;
     display: grid;
-    grid-template-columns: 12rem 1fr;
+    grid-template-columns: auto 1fr;
 
     border-radius: styles.$normal-border-radius;
     overflow: hidden;
-}
-
-.chartList {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-
-    width: 100%;
-    height: 100%;
-    background-color: #fcfcfc;
-    padding: 1rem;
-    overflow: auto;
-
-    border: 1px solid black;
-    border-left: 0;
 }

--- a/src/components/ChartMenu/ChartMenu.tsx
+++ b/src/components/ChartMenu/ChartMenu.tsx
@@ -1,80 +1,17 @@
 import { useSelector } from "react-redux";
-import { useInterval } from "@hooks/useInterval";
 import Sidebar from "@components/ChartMenu/Sidebar/Sidebar";
 import styles from "@components/ChartMenu/ChartMenu.module.scss";
-import { DragEvent, useEffect } from "react";
-import { Chart } from "@components/ChartMenu/Chart/Chart";
-import { selectPodDataNames } from "@slices/podDataSlice";
+import { selectNumericPodDataNames } from "@slices/podDataSlice";
 import lodash from "lodash";
-import { useChartElements } from "./useChartElements";
-import { store } from "../../store";
-import { getMeasurement } from "@models/PodData/PodData";
+import { ChartList } from "@components/ChartMenu/ChartList/ChartList";
+import { TreeNode } from "@components/ChartMenu/TreeNode";
+
 export const ChartMenu = () => {
-    let boardNodes = useSelector(selectPodDataNames, lodash.isEqual);
-
-    const [
-        chartElements,
-        addElement,
-        addLineToElement,
-        updateElements,
-        removeElement,
-        removeLineItem,
-    ] = useChartElements();
-
-    function getUpdatedMeasurements(): Map<string, string> {
-        let state = store.getState();
-        let measurements = new Map<string, string>();
-        for (let element of chartElements) {
-            for (let [name, _] of element.lines) {
-                measurements.set(
-                    name,
-                    //TODO: HACER QUE SOLO APAREZCAN EN EL SIDEBAR LOS QUE SON NUMEROS ASI NO HAY QUE CONVERTIR LUEGO
-                    getMeasurement(state.podData.boards, name).value as string
-                );
-            }
-        }
-        return measurements;
-    }
-
-    useInterval(() => {
-        updateElements(getUpdatedMeasurements());
-    }, 1000 / 60);
-
-    function handleDrop(ev: DragEvent<HTMLDivElement>) {
-        addElement(ev.dataTransfer.getData("text/plain"));
-    }
-
-    function handleDropOnChart(id: number, measurementName: string) {
-        addLineToElement(id, measurementName);
-    }
-
+    const boardNodes = useSelector(selectNumericPodDataNames, lodash.isEqual);
     return (
-        <div id={styles.wrapper}>
+        <div className={styles.wrapper}>
             <Sidebar boardNodes={boardNodes} />
-            <div
-                id={styles.chartList}
-                onDrop={handleDrop}
-                onDragEnter={(ev) => {
-                    ev.preventDefault();
-                }}
-                onDragOver={(ev) => {
-                    ev.preventDefault();
-                }}
-            >
-                {chartElements.map((chartElement) => {
-                    return (
-                        <Chart
-                            key={chartElement.id}
-                            chartElement={chartElement}
-                            handleDropOnChart={handleDropOnChart}
-                            removeElement={() => removeElement(chartElement.id)}
-                            removeLineItem={(lineId: string) => {
-                                removeLineItem(chartElement.id, lineId);
-                            }}
-                        />
-                    );
-                })}
-            </div>
+            <ChartList></ChartList>
         </div>
     );
 };

--- a/src/components/ChartMenu/Sidebar/BoardItem/BoardItem.module.scss
+++ b/src/components/ChartMenu/Sidebar/BoardItem/BoardItem.module.scss
@@ -1,20 +1,28 @@
 @use "@styles/styles";
-#header {
-    margin-bottom: 1rem;
-    padding: 0.5rem;
-    background-color: #e4e5e7;
 
-    @include styles.normal-text-style;
-    color: #505868;
+.wrapper {
+    display: grid;
+    grid-template-rows: auto auto;
+
+    gap: 1rem;
+    background-color: styles.lightness(styles.$base-color, 35%);
+    @include styles.code-text;
+}
+
+.header {
+    padding: 0.5rem;
+    background-color: styles.lightness(styles.$base-color, 30%);
+
+    color: styles.$base-color;
     font-weight: bold;
 }
 
-#packetList {
+.packetList {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
-}
+    padding-right: 1.5rem;
 
-.treeNode {
-    margin-left: 0.8rem;
+    > * {
+        margin-bottom: 0.8rem;
+    }
 }

--- a/src/components/ChartMenu/Sidebar/BoardItem/BoardItem.module.scss
+++ b/src/components/ChartMenu/Sidebar/BoardItem/BoardItem.module.scss
@@ -1,27 +1,31 @@
 @use "@styles/styles";
 
 .wrapper {
-    display: grid;
-    grid-template-rows: auto auto;
+    display: flex;
+    flex-direction: column;
 
-    gap: 1rem;
-    background-color: styles.lightness(styles.$base-color, 35%);
     @include styles.code-text;
 }
 
 .header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.4rem;
     padding: 0.5rem;
     background-color: styles.lightness(styles.$base-color, 30%);
 
     color: styles.$base-color;
     font-weight: bold;
+
+    border-bottom: 1px solid styles.lightness(styles.$base-color, 18%);
 }
 
 .packetList {
     display: flex;
     flex-direction: column;
     padding-right: 1.5rem;
-
+    overflow: hidden;
     > * {
         margin-bottom: 0.8rem;
     }

--- a/src/components/ChartMenu/Sidebar/BoardItem/BoardItem.tsx
+++ b/src/components/ChartMenu/Sidebar/BoardItem/BoardItem.tsx
@@ -10,8 +10,8 @@ type Props = {
 
 export const BoardItem = ({ name, packetNodes }: Props) => {
     return (
-        <div id={styles.wrapper}>
-            <div id={styles.header}>{name}</div>
+        <div className={styles.wrapper}>
+            <div className={styles.header}>{name}</div>
             <PacketItems packetNodes={packetNodes} />
         </div>
     );
@@ -19,7 +19,7 @@ export const BoardItem = ({ name, packetNodes }: Props) => {
 
 const PacketItems = ({ packetNodes }: { packetNodes: TreeNode }) => {
     return (
-        <div id={`${styles.packetList} ${styles.treeNode}`}>
+        <div className={`${styles.packetList} treeNode`}>
             {Object.entries(packetNodes).map(([name, measurementNodes]) => {
                 return (
                     <PacketItem

--- a/src/components/ChartMenu/Sidebar/BoardItem/BoardItem.tsx
+++ b/src/components/ChartMenu/Sidebar/BoardItem/BoardItem.tsx
@@ -2,6 +2,8 @@ import styles from "@components/ChartMenu/Sidebar/BoardItem/BoardItem.module.scs
 import { Board } from "@models/PodData/Board";
 import PacketItem from "@components/ChartMenu/Sidebar/PacketItem/PacketItem";
 import { TreeNode } from "@components/ChartMenu/TreeNode";
+import { Caret } from "@components/Caret/Caret";
+import { useState } from "react";
 
 type Props = {
     name: string;
@@ -9,17 +11,35 @@ type Props = {
 };
 
 export const BoardItem = ({ name, packetNodes }: Props) => {
+    const [isOpen, setIsOpen] = useState(false);
     return (
         <div className={styles.wrapper}>
-            <div className={styles.header}>{name}</div>
-            <PacketItems packetNodes={packetNodes} />
+            <div className={styles.header}>
+                <Caret
+                    isOpen={isOpen}
+                    onClick={() => {
+                        setIsOpen((prev) => !prev);
+                    }}
+                />
+                {name}
+            </div>
+            <PacketItems packetNodes={packetNodes} isVisible={isOpen} />
         </div>
     );
 };
 
-const PacketItems = ({ packetNodes }: { packetNodes: TreeNode }) => {
+const PacketItems = ({
+    packetNodes,
+    isVisible,
+}: {
+    packetNodes: TreeNode;
+    isVisible: boolean;
+}) => {
     return (
-        <div className={`${styles.packetList} treeNode`}>
+        <div
+            className={`${styles.packetList} treeNode`}
+            style={{ height: isVisible ? "auto" : "0" }}
+        >
             {Object.entries(packetNodes).map(([name, measurementNodes]) => {
                 return (
                     <PacketItem

--- a/src/components/ChartMenu/Sidebar/MeasurementItem/MeasurementItem.module.scss
+++ b/src/components/ChartMenu/Sidebar/MeasurementItem/MeasurementItem.module.scss
@@ -1,16 +1,10 @@
 @use "@styles/styles";
 
-.treeNode {
-    margin-left: 0.8rem;
-}
-
 .wrapper {
     display: grid;
     align-items: center;
     grid-template-columns: auto 1fr;
     column-gap: 0.3rem;
-    @include styles.normal-text-style;
     font-weight: 500;
-    color: #505868;
     cursor: pointer;
 }

--- a/src/components/ChartMenu/Sidebar/MeasurementItem/MeasurementItem.tsx
+++ b/src/components/ChartMenu/Sidebar/MeasurementItem/MeasurementItem.tsx
@@ -3,24 +3,24 @@ import { Measurement } from "@models/PodData/Measurement";
 import { DragEvent, memo } from "react";
 import { FiBox } from "react-icons/fi";
 type Props = {
-  name: string;
+    name: string;
 };
 
 const MeasurementItem = ({ name }: Props) => {
-  function handleDragStart(ev: DragEvent<HTMLDivElement>) {
-    ev.dataTransfer.setData("text/plain", name);
-  }
+    function handleDragStart(ev: DragEvent<HTMLDivElement>) {
+        ev.dataTransfer.setData("text/plain", name);
+    }
 
-  return (
-    <div
-      key={name}
-      className={`${styles.wrapper} ${styles.treeNode}`}
-      draggable="true"
-      onDragStart={handleDragStart}
-    >
-      <FiBox /> {name}
-    </div>
-  );
+    return (
+        <div
+            key={name}
+            className={`${styles.wrapper} treeNode`}
+            draggable="true"
+            onDragStart={handleDragStart}
+        >
+            <FiBox /> {name}
+        </div>
+    );
 };
 
 export default MeasurementItem;

--- a/src/components/ChartMenu/Sidebar/PacketItem/PacketItem.module.scss
+++ b/src/components/ChartMenu/Sidebar/PacketItem/PacketItem.module.scss
@@ -1,22 +1,11 @@
 @use "@styles/styles";
-#wrapper {
+.wrapper {
     display: flex;
     flex-direction: column;
-    margin-bottom: 0.5rem;
 }
 
-#name {
+.name {
     margin-bottom: 0.5rem;
-
-    @include styles.normal-text-style;
     font-style: italic;
     color: #a9adb6;
-}
-
-#measurementList {
-    @include styles.normal-text-style;
-}
-
-.treeNode {
-    margin-left: 0.8rem;
 }

--- a/src/components/ChartMenu/Sidebar/PacketItem/PacketItem.tsx
+++ b/src/components/ChartMenu/Sidebar/PacketItem/PacketItem.tsx
@@ -9,8 +9,8 @@ type Props = {
 
 const PacketItem = ({ name, measurementNodes }: Props) => {
     return (
-        <div id={styles.wrapper} className={`${styles.treeNode}`}>
-            <div id={styles.name}>{name}</div>
+        <div className={`${styles.wrapper} treeNode`}>
+            <div className={styles.name}>{name}</div>
             <MeasurementItems measurementNodes={measurementNodes} />
         </div>
     );
@@ -22,7 +22,7 @@ const MeasurementItems = ({
     measurementNodes: TreeNode;
 }) => {
     return (
-        <div id={styles.measurementList}>
+        <div className={styles.measurementList}>
             {Object.keys(measurementNodes).map((name) => {
                 return <MeasurementItem key={name} name={name} />;
             })}

--- a/src/components/ChartMenu/Sidebar/Sidebar.module.scss
+++ b/src/components/ChartMenu/Sidebar/Sidebar.module.scss
@@ -6,4 +6,6 @@
     display: flex;
     flex-direction: column;
     overflow: auto;
+
+    background-color: styles.lightness(styles.$base-color, 35%);
 }

--- a/src/components/ChartMenu/Sidebar/Sidebar.module.scss
+++ b/src/components/ChartMenu/Sidebar/Sidebar.module.scss
@@ -1,11 +1,9 @@
 @use "@styles/styles";
-#wrapper {
-    width: 100%;
+.wrapper {
+    width: auto;
     height: 100%;
 
     display: flex;
     flex-direction: column;
-
-    background-color: #f2f2f2;
     overflow: auto;
 }

--- a/src/components/ChartMenu/Sidebar/Sidebar.tsx
+++ b/src/components/ChartMenu/Sidebar/Sidebar.tsx
@@ -1,4 +1,5 @@
 import styles from "@components/ChartMenu/Sidebar/Sidebar.module.scss";
+import "@components/ChartMenu/Sidebar/treeNode.scss";
 import { BoardItem } from "@components/ChartMenu/Sidebar/BoardItem/BoardItem";
 import { memo } from "react";
 import { TreeNode } from "@components/ChartMenu/TreeNode";
@@ -9,7 +10,7 @@ type Props = {
 
 const Sidebar = ({ boardNodes }: Props) => {
     return (
-        <div id={styles.wrapper}>
+        <div className={styles.wrapper}>
             {Object.entries(boardNodes).map(([name, packetNodes]) => {
                 return (
                     <BoardItem

--- a/src/components/ChartMenu/Sidebar/treeNode.scss
+++ b/src/components/ChartMenu/Sidebar/treeNode.scss
@@ -1,0 +1,3 @@
+.treeNode {
+    margin-left: 0.8rem;
+}

--- a/src/components/ChartMenu/useChartElements.ts
+++ b/src/components/ChartMenu/useChartElements.ts
@@ -1,116 +1,132 @@
 import { useState, useRef } from "react";
 import { ChartElement, LineFigure } from "@components/ChartMenu/ChartElement";
-import { HSLColor } from "@utils/color";
+import { HSLAColor } from "@utils/color";
 
-function getColor(offset: number): HSLColor {
-  return {
-    h: (32 + offset * 50) % 360,
-    s: 70,
-    l: 75,
-  };
+function getColor(offset: number): HSLAColor {
+    return {
+        h: (32 + offset * 50) % 360,
+        s: 90,
+        l: 75,
+        a: 1,
+    };
 }
 
 export function useChartElements(): [
-  ChartElement[],
-  (measurementName: string) => void,
-  (id: number, measurementName: string) => void,
-  (updatedMeasurements: Map<string, string>) => void,
-  (id: number) => void,
-  (chartId: number, lineItemId: string) => void
+    ChartElement[],
+    (measurementName: string) => void,
+    (id: number, measurementName: string) => void,
+    (updatedMeasurements: Map<string, number>) => void,
+    (id: number) => void,
+    (chartId: number, lineItemId: string) => void
 ] {
-  const [chartElements, setChartElements] = useState([] as ChartElement[]);
-  const chartIndex = useRef(0);
+    const [chartElements, setChartElements] = useState([] as ChartElement[]);
+    const chartIndex = useRef(0);
 
-  function addElement(measurementName: string): void {
-    const newElement = {
-      id: chartIndex.current,
-      lines: new Map([
-        [measurementName, new LineFigure(measurementName, getColor(0))],
-      ]),
-    };
+    function addElement(measurementName: string): void {
+        const newElement = {
+            id: chartIndex.current,
+            lines: new Map([
+                [measurementName, new LineFigure(measurementName, getColor(0))],
+            ]),
+        };
 
-    setChartElements((prevElements) => {
-      return [...prevElements, newElement];
-    });
-    chartIndex.current++;
-  }
-
-  function addLineToElement(id: number, measurementName: string): void {
-    if (isAlreadyInChart(id, measurementName)) {
-      return;
-    } else {
-      setChartElements((prevElements) => {
-        const index = prevElements.findIndex((element) => element.id == id);
-        const newElement = { ...prevElements[index] };
-
-        newElement.lines = new Map(
-          newElement.lines.set(
-            measurementName,
-            new LineFigure(measurementName, getColor(newElement.lines.size + 1))
-          )
-        );
-
-        return replaceElement(prevElements, newElement, index);
-      });
+        setChartElements((prevElements) => {
+            return [...prevElements, newElement];
+        });
+        chartIndex.current++;
     }
-  }
 
-  function isAlreadyInChart(id: number, measurementName: string): boolean {
-    let index = chartElements.findIndex((element) => element.id == id)!;
-    return chartElements[index].lines.has(measurementName);
-  }
+    function addLineToElement(id: number, measurementName: string): void {
+        if (isAlreadyInChart(id, measurementName)) {
+            return;
+        } else {
+            setChartElements((prevElements) => {
+                const index = prevElements.findIndex(
+                    (element) => element.id == id
+                );
+                const newElement = { ...prevElements[index] };
 
-  function replaceElement<T>(elementArr: T[], element: T, index: number): T[] {
-    return Object.assign([], elementArr, { index: element });
-  }
+                newElement.lines = new Map(
+                    newElement.lines.set(
+                        measurementName,
+                        new LineFigure(
+                            measurementName,
+                            getColor(newElement.lines.size + 1)
+                        )
+                    )
+                );
 
-  function updateElements(updatedMeasurements: Map<string, string>): void {
-    setChartElements((prevElements) => {
-      return prevElements.map((element) => {
-        for (let [name, value] of updatedMeasurements) {
-          if (element.lines.has(name)) {
-            let line = element.lines.get(name)!;
-            line.updateVector(Number.parseFloat(value));
-            element.lines.set(name, line);
-            let newLines = new Map(element.lines);
-            element.lines = newLines;
-          }
+                return replaceElement(prevElements, newElement, index);
+            });
         }
-        return element;
-      });
-    });
-  }
+    }
 
-  function removeElement(id: number): void {
-    setChartElements((prevElements) => {
-      return prevElements.filter((element) => {
-        return element.id != id;
-      });
-    });
-  }
+    function isAlreadyInChart(id: number, measurementName: string): boolean {
+        let index = chartElements.findIndex((element) => element.id == id)!;
+        return chartElements[index].lines.has(measurementName);
+    }
 
-  function removeLineItem(chartId: number, lineItemId: string) {
-    setChartElements((prevElements) => {
-      let elementIndex = prevElements.findIndex(
-        (element) => element.id == chartId
-      );
-      let newChartElement = prevElements[elementIndex];
+    function replaceElement<T>(
+        elementArr: T[],
+        element: T,
+        index: number
+    ): T[] {
+        return Object.assign([], elementArr, { index: element });
+    }
 
-      newChartElement.lines.delete(lineItemId);
-      if (newChartElement.lines.size == 0) {
-        return [...prevElements].filter((element) => element.id != chartId);
-      } else {
-        return replaceElement(prevElements, newChartElement, elementIndex);
-      }
-    });
-  }
+    function updateElements(updatedMeasurements: Map<string, number>): void {
+        setChartElements((prevElements) => {
+            return prevElements.map((element) => {
+                for (let [name, value] of updatedMeasurements) {
+                    if (element.lines.has(name)) {
+                        let line = element.lines.get(name)!;
+                        line.updateVector(value);
+                        element.lines.set(name, line);
+                        let newLines = new Map(element.lines);
+                        element.lines = newLines;
+                    }
+                }
+                return element;
+            });
+        });
+    }
 
-  return [
-    chartElements,
-    addElement,
-    addLineToElement,
-    updateElements,
-    removeElement,
-    removeLineItem,
-  ];
+    function removeElement(id: number): void {
+        setChartElements((prevElements) => {
+            return prevElements.filter((element) => {
+                return element.id != id;
+            });
+        });
+    }
+
+    function removeLineItem(chartId: number, lineItemId: string) {
+        setChartElements((prevElements) => {
+            let elementIndex = prevElements.findIndex(
+                (element) => element.id == chartId
+            );
+            let newChartElement = prevElements[elementIndex];
+
+            newChartElement.lines.delete(lineItemId);
+            if (newChartElement.lines.size == 0) {
+                return [...prevElements].filter(
+                    (element) => element.id != chartId
+                );
+            } else {
+                return replaceElement(
+                    prevElements,
+                    newChartElement,
+                    elementIndex
+                );
+            }
+        });
+    }
+
+    return [
+        chartElements,
+        addElement,
+        addLineToElement,
+        updateElements,
+        removeElement,
+        removeLineItem,
+    ];
 }

--- a/src/hooks/useId.ts
+++ b/src/hooks/useId.ts
@@ -1,0 +1,5 @@
+import { useRef } from "react";
+
+export function useId(): string {
+    return useRef(crypto.randomUUID()).current;
+}

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -8,7 +8,7 @@ $normal-text-color: #373c43;
 $alternate-text-color: #505868;
 $orange: #f28d30;
 $blue: #317ae7;
-$base-color: #64849c;
+$base-color: hsl(212, 27%, 55%);
 
 //DARK THEME
 $dark-isle-color: #404654;


### PR DESCRIPTION
With this PR, only numeric measurements will be showed in the sidebar. That means that you won't be able to create charts for enums or booleans, which makes perfect sense. It also breaks down ChartMenu into smaller components so that it more decoupled (ChartList component). The reason this is a draft pull request is because I want the sidebar to be collapsable and I want to change the colors.

For clarification:
- `ChartElement` is the model that holds the data of a `Chart` component
- `ChartList` is a component that holds a list of `Chart` components
- `ChartMenu` holds both the `Sidebar` and `ChartList`
- `BoardItem`, `PacketItem` and `MeasurementItem` represent each level in the `Sidebar`
- `useChartElements` is a hook that handles the state of the `ChartList` component
- `useId` is a hook that generates a random id that is kept between rerenders.

Beware that some files appear as changed because of the change in identation, those can be safely ignored.